### PR TITLE
Update clang from 14 to 15

### DIFF
--- a/.github/workflows/bvt-clang15.yml
+++ b/.github/workflows/bvt-clang15.yml
@@ -15,6 +15,8 @@ jobs:
 
     - name: install clang 15
       run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" -y
         sudo apt update
         sudo apt install -y clang-15
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-15 15

--- a/.github/workflows/bvt-clang15.yml
+++ b/.github/workflows/bvt-clang15.yml
@@ -6,19 +6,19 @@ on:
         required: false
 
 jobs:
-  bvt-clang14:
+  bvt-clang15:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.branch }}
 
-    - name: install clang 14
+    - name: install clang 15
       run: |
         sudo apt update
-        sudo apt install -y clang-14
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-14 14
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-14 14
+        sudo apt install -y clang-15
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-15 15
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-15 15
 
     - name: check compiler version
       run: g++ --version

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -15,9 +15,9 @@ jobs:
     uses: ./.github/workflows/bvt-gcc11.yml
     name: run bvt with g++ 11
 
-  run-bvt-clang14:
-    uses: ./.github/workflows/bvt-clang14.yml
-    name: run bvt with clang 14
+  run-bvt-clang15:
+    uses: ./.github/workflows/bvt-clang15.yml
+    name: run bvt with clang 15
 
   run-bvt-msvc14:
     uses: ./.github/workflows/bvt-msvc14.yml

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -44,10 +44,10 @@ jobs:
     with:
       branch: release/${{ github.event.inputs.version }}
 
-  run-bvt-clang14:
+  run-bvt-clang15:
     needs: prepare-release
-    name: run bvt with clang 14
-    uses: ./.github/workflows/bvt-clang14.yml
+    name: run bvt with clang 15
+    uses: ./.github/workflows/bvt-clang15.yml
     with:
       branch: release/${{ github.event.inputs.version }}
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ pro::proxy<DrawableFacade> CreateRectangleAsDrawable(int width, int height) {
 }
 ```
 
-Please find more details and discussions in the spec. The complete version of the "drawable" demo could be found in [tests/proxy_integration_tests.cpp](tests/proxy_integration_tests.cpp).
+Please find more details and discussions in the spec. The complete version of the "drawable" demo could be found in [tests/proxy_integration_tests.cpp](tests/proxy_integration_tests.cpp) (also available on [Compiler Explorer](https://godbolt.org/z/5a3jeE1M8)).
 
 ## Minimum requirements for compilers
 
 | Family | Minimum version | Required flags |
 | --- | --- | --- |
-| clang | 13.0.0 | -std=c++20 |
+| clang | 15.0.0 | -std=c++20 |
 | gcc | 11.2 | -std=c++20 |
 | MSVC | 19.30 | /std:c++20 |
 
@@ -110,10 +110,6 @@ cmake --build ./build -j8
 cd ./build
 ctest -j8
 ```
-
-## Known issues
-
-We did not notice a bug when testing with gcc or MSVC, but clang will fail to compile if the `minimum_destructibility` is set to `constraint_level::trivial` in a facade definition. The root cause of this failure is that the implementation requires the language feature defined in [P0848R3: Conditionally Trivial Special Member Functions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0848r3.html), but it has not been implemented in clang, according to its [documentation](https://clang.llvm.org/cxx_status.html) for the time being.
 
 ## Contributing
 

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -107,7 +107,6 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableSmallFacade>, Mock
 static_assert(!std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
 static_assert(!std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
 
-#ifndef __clang__
 struct TrivialFacade : pro::facade<> {
   static constexpr auto minimum_copyability = pro::constraint_level::trivial;
   static constexpr auto minimum_relocatability = pro::constraint_level::trivial;
@@ -132,6 +131,5 @@ static_assert(!std::is_constructible_v<pro::proxy<TrivialFacade>, MockCopyableSm
 static_assert(!std::is_assignable_v<pro::proxy<TrivialFacade>, MockCopyableSmallPtr>);
 static_assert(std::is_nothrow_constructible_v<pro::proxy<TrivialFacade>, MockTrivialPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<TrivialFacade>, MockTrivialPtr>);
-#endif  // __clang__
 
 }  // namespace


### PR DESCRIPTION
Since Clang 15 has partially implemented [P0848R3](https://wg21.link/p0848r3), the known issue no longer exists and hence removed from README.md. Also, some the excluded test cases from clang unit tests were added back.