### PR TITLE
fix unittest in gcc13

### DIFF
--- a/.github/workflows/bvt-gcc13.yml
+++ b/.github/workflows/bvt-gcc13.yml
@@ -6,19 +6,19 @@ on:
         required: false
 
 jobs:
-  bvt-gcc11:
+  bvt-gcc13:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.branch }}
 
-    - name: install gcc 11
+    - name: install gcc 13
       run: |
         sudo apt update
-        sudo apt install -y gcc-11 g++-11
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
+        sudo apt install -y gcc-13 g++-13
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
 
     - name: check compiler version
       run: g++ --version

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -11,9 +11,9 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  run-bvt-gcc11:
-    uses: ./.github/workflows/bvt-gcc11.yml
-    name: run bvt with g++ 11
+  run-bvt-gcc13:
+    uses: ./.github/workflows/bvt-gcc13.yml
+    name: run bvt with g++ 13
 
   run-bvt-clang15:
     uses: ./.github/workflows/bvt-clang15.yml

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -37,10 +37,10 @@ jobs:
         git push origin release/${{ github.event.inputs.version }}
         git push origin ${{ github.event.inputs.version }}
 
-  run-bvt-gcc11:
+  run-bvt-gcc13:
     needs: prepare-release
-    name: run bvt with g++ 11
-    uses: ./.github/workflows/bvt-gcc11.yml
+    name: run bvt with g++ 13
+    uses: ./.github/workflows/bvt-gcc13.yml
     with:
       branch: release/${{ github.event.inputs.version }}
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -641,10 +641,15 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToSelf) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
+#elif defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
 #endif  // __clang__
     p = std::move(p);
 #ifdef __clang__
 #pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
 #endif  // __clang__
     ASSERT_FALSE(p.has_value());
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -693,10 +698,15 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToSelf) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
+#elif defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
 #endif  // __clang__
   p = std::move(p);
 #ifdef __clang__
 #pragma clang diagnostic pop
+#elif defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
 #endif  // __clang__
   ASSERT_FALSE(p.has_value());
 }


### PR DESCRIPTION
GCC13 added a new warning `Wself-move` (regarding info https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81159). Therefore, the relevant codes in unittest will throw errors as `-Werror` is opened.

Add a diagnostic pragma to remove the errors.