### PR TITLE
Feature: Support overloads in dispatch definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ All the facilities of the library are defined in namespace `pro`. The 3 major cl
 ```cpp
 // Abstraction
 struct Draw : pro::dispatch<void(std::ostream&)> {
-  template <class T>
-  void operator()(const T& self, std::ostream& out) { self.Draw(out); }
+  void operator()(const auto& self, std::ostream& out) { self.Draw(out); }
 };
 struct Area : pro::dispatch<double()> {
-  template <class T>
-  double operator()(const T& self) { return self.Area(); }
+  double operator()(const auto& self) { return self.Area(); }
 };
 struct DrawableFacade : pro::facade<Draw, Area> {};
 

--- a/proxy.h
+++ b/proxy.h
@@ -15,10 +15,10 @@ namespace pro {
 
 enum class constraint_level { none, nontrivial, nothrow, trivial };
 
-template <class Os, auto CPO = nullptr>
-struct dispatch {
-  using overload_types = Os;
-
+template <class... Os>
+struct dispatch { using overload_types = std::tuple<Os...>; };
+template <auto CPO, class... Os>
+struct dispatch_adaptor : dispatch<Os...> {
   template <class T, class... Args>
       requires(std::is_invocable_v<decltype(CPO)&, T, Args...>)
   constexpr decltype(auto) operator()(T&& value, Args&&... args) const

--- a/proxy.h
+++ b/proxy.h
@@ -134,7 +134,7 @@ template <class Os, std::size_t... Is>
 struct overload_resolution_traits_impl<Os, std::index_sequence<Is...>> {
  private:
   template <std::size_t I>
-  using single_resolver = overload_traits<std::tuple_element_t<I, Os>>
+  using single_resolver = typename overload_traits<std::tuple_element_t<I, Os>>
       ::template resolver<std::integral_constant<std::size_t, I>>;
 
  public:

--- a/proxy.h
+++ b/proxy.h
@@ -109,7 +109,7 @@ struct flattening_traits<std::tuple<T, Ts...>> : flattening_traits_impl<
     typename flattening_traits<T>::type,
     typename flattening_traits<std::tuple<Ts...>>::type> {};
 
-template <class... U> struct default_traits { using type = void; };
+template <class... Ts> struct default_traits { using type = void; };
 template <class T> struct default_traits<T> { using type = T; };
 
 template <class O> struct overload_traits : inapplicable_traits {};
@@ -282,8 +282,8 @@ template <class F> struct facade_traits : facade_traits_impl<
     F, typename flattening_traits<typename F::dispatch_types>::type> {};
 
 template <class T, class...> struct dependent_traits { using type = T; };
-template <class T, class... U>
-using dependent_t = typename dependent_traits<T, U...>::type;
+template <class T, class... Us>
+using dependent_t = typename dependent_traits<T, Us...>::type;
 
 }  // namespace details
 

--- a/proxy.h
+++ b/proxy.h
@@ -117,7 +117,7 @@ template <class R, class... Args>
 struct overload_traits<R(Args...)> : applicable_traits {
   using dispatcher_type = R (*)(const char*, Args...);
   template <class T>
-  struct resolver { T operator()(Args&&...); };
+  struct resolver { T operator()(Args...); };
 
   template <class D, class T>
   static constexpr bool applicable_operand = requires(T operand, Args... args)

--- a/proxy.h
+++ b/proxy.h
@@ -495,8 +495,8 @@ class proxy {
   decltype(auto) operator()(Args&&... args) const
       requires(!std::is_void_v<DefaultDispatch> &&
           details::dependent_t<Traits, Args...>::applicable &&
-          details::dispatch_traits<DefaultDispatch>
-              ::template has_overload<Args...>)
+          details::dependent_t<details::dispatch_traits<DefaultDispatch>
+              , Args...>::template has_overload<Args...>)
       { return invoke(std::forward<Args>(args)...); }
 
  private:

--- a/proxy.h
+++ b/proxy.h
@@ -116,8 +116,7 @@ template <class O> struct overload_traits : inapplicable_traits {};
 template <class R, class... Args>
 struct overload_traits<R(Args...)> : applicable_traits {
   using dispatcher_type = R (*)(const char*, Args...);
-  template <class T>
-  struct resolver { T operator()(Args...); };
+  template <class T> struct resolver { T operator()(Args...); };
 
   template <class D, class T>
   static constexpr bool applicable_operand = requires(T operand, Args... args)

--- a/proxy.h
+++ b/proxy.h
@@ -15,13 +15,12 @@ namespace pro {
 
 enum class constraint_level { none, nontrivial, nothrow, trivial };
 
-template <class T, auto CPO = nullptr> struct dispatch;
-template <class R, class... Args, auto CPO>
-struct dispatch<R(Args...), CPO> {
-  using return_type = R;
-  using argument_types = std::tuple<Args...>;
+template <class Os, auto CPO = nullptr>
+struct dispatch {
+  using overload_types = Os;
 
-  template <class T> requires(std::is_invocable_v<decltype(CPO)&, T, Args...>)
+  template <class T, class... Args>
+      requires(std::is_invocable_v<decltype(CPO)&, T, Args...>)
   constexpr decltype(auto) operator()(T&& value, Args&&... args) const
       { return CPO(std::forward<T>(value), std::forward<Args>(args)...); }
 };
@@ -92,39 +91,92 @@ struct contains_traits<T, T, Us...> : applicable_traits {};
 template <class T, class U, class... Us>
 struct contains_traits<T, U, Us...> : contains_traits<T, Us...> {};
 
+template <class T, class U> struct flattening_traits_impl;
+template <class T>
+struct flattening_traits_impl<std::tuple<>, T> { using type = T; };
+template <class T, class... Ts, class U>
+struct flattening_traits_impl<std::tuple<T, Ts...>, U>
+    : flattening_traits_impl<std::tuple<Ts...>, U> {};
+template <class T, class... Ts, class... Us>
+    requires(!contains_traits<T, Us...>::applicable)
+struct flattening_traits_impl<std::tuple<T, Ts...>, std::tuple<Us...>>
+    : flattening_traits_impl<std::tuple<Ts...>, std::tuple<Us..., T>> {};
+template <class T> struct flattening_traits { using type = std::tuple<T>; };
+template <>
+struct flattening_traits<std::tuple<>> { using type = std::tuple<>; };
+template <class T, class... Ts>
+struct flattening_traits<std::tuple<T, Ts...>> : flattening_traits_impl<
+    typename flattening_traits<T>::type,
+    typename flattening_traits<std::tuple<Ts...>>::type> {};
+
 template <class... U> struct default_traits { using type = void; };
 template <class T> struct default_traits<T> { using type = T; };
 
-template <class D, class Args>
-struct dispatch_traits_impl : inapplicable_traits {};
-template <class D, class... Args>
-struct dispatch_traits_impl<D, std::tuple<Args...>> : applicable_traits {
-  using dispatcher_type = typename D::return_type (*)(const char*, Args...);
-
+template <class O> struct overload_traits : inapplicable_traits {};
+template <class R, class... Args>
+struct overload_traits<R(Args...)> : applicable_traits {
+  using dispatcher_type = R (*)(const char*, Args...);
   template <class T>
+  struct resolver { T operator()(Args&&...); };
+
+  template <class D, class T>
   static constexpr bool applicable_operand = requires(T operand, Args... args)
       { { D{}(std::forward<T>(operand), std::forward<Args>(args)...) }; };
-  template <class P>
-  static typename D::return_type dispatcher(const char* p, Args... args) {
+  template <class D, class P>
+  static R dispatcher(const char* p, Args... args) {
     return D{}(**reinterpret_cast<const P*>(p), std::forward<Args>(args)...);
   }
 };
+
+template <class Os, class Is>
+struct overload_resolution_traits_impl;
+template <class Os, std::size_t... Is>
+struct overload_resolution_traits_impl<Os, std::index_sequence<Is...>> {
+ private:
+  template <std::size_t I>
+  using single_resolver = overload_traits<std::tuple_element_t<I, Os>>
+      ::template resolver<std::integral_constant<std::size_t, I>>;
+
+ public:
+  struct resolver : single_resolver<Is>...
+      { using single_resolver<Is>::operator()...; };
+};
+template <class Os>
+struct overload_resolution_traits : overload_resolution_traits_impl<
+    Os, std::make_index_sequence<std::tuple_size_v<Os>>> {};
+
+template <class D, class Os>
+struct dispatch_traits_impl : inapplicable_traits {};
+template <class D, class... Os>
+    requires(sizeof...(Os) > 0u && (overload_traits<Os>::applicable && ...))
+struct dispatch_traits_impl<D, std::tuple<Os...>> : applicable_traits {
+  using dispatcher_types =
+      std::tuple<typename overload_traits<Os>::dispatcher_type...>;
+  using overload_resolver =
+      typename overload_resolution_traits<std::tuple<Os...>>::resolver;
+
+  template <class T>
+  static constexpr bool applicable_operand =
+      (overload_traits<Os>::template applicable_operand<D, T> && ...);
+  template <class P>
+  static constexpr dispatcher_types dispatchers{
+      overload_traits<Os>::template dispatcher<D, P>...};
+};
 template <class D> struct dispatch_traits : inapplicable_traits {};
 template <class D> requires(requires {
-      typename D::return_type;
-      typename D::argument_types;
+      typename D::overload_types;
       { D{} };
     })
-struct dispatch_traits<D>
-    : dispatch_traits_impl<D, typename D::argument_types> {};
+struct dispatch_traits<D> : dispatch_traits_impl<
+    D, typename flattening_traits<typename D::overload_types>::type> {};
 
 template <class D>
 struct dispatch_meta {
   template <class P>
   constexpr explicit dispatch_meta(std::in_place_type_t<P>)
-      : dispatcher(dispatch_traits<D>::template dispatcher<P>) {}
+      : dispatchers(dispatch_traits<D>::template dispatchers<P>) {}
 
-  typename dispatch_traits<D>::dispatcher_type dispatcher;
+  typename dispatch_traits<D>::dispatcher_types dispatchers;
 };
 struct copy_meta {
   template <class P>
@@ -176,24 +228,6 @@ template <class M, class... Ms>
 struct facade_meta_traits<M, Ms...> : facade_meta_traits_impl<
     M, typename facade_meta_traits<Ms...>::type> {};
 template <> struct facade_meta_traits<> { using type = facade_meta<>; };
-
-template <class T, class U> struct flattening_traits_impl;
-template <class T>
-struct flattening_traits_impl<std::tuple<>, T> { using type = T; };
-template <class T, class... Ts, class U>
-struct flattening_traits_impl<std::tuple<T, Ts...>, U>
-    : flattening_traits_impl<std::tuple<Ts...>, U> {};
-template <class T, class... Ts, class... Us>
-    requires(!contains_traits<T, Us...>::applicable)
-struct flattening_traits_impl<std::tuple<T, Ts...>, std::tuple<Us...>>
-    : flattening_traits_impl<std::tuple<Ts...>, std::tuple<Us..., T>> {};
-template <class T> struct flattening_traits { using type = std::tuple<T>; };
-template <>
-struct flattening_traits<std::tuple<>> { using type = std::tuple<>; };
-template <class T, class... Ts>
-struct flattening_traits<std::tuple<T, Ts...>> : flattening_traits_impl<
-    typename flattening_traits<T>::type,
-    typename flattening_traits<std::tuple<Ts...>>::type> {};
 
 template <class F, class Ds> struct basic_facade_traits_impl;
 template <class F, class... Ds>
@@ -446,11 +480,15 @@ class proxy {
   decltype(auto) invoke(Args&&... args) const
       requires(details::dependent_t<Traits, D>::applicable &&
           BasicTraits::template has_dispatch<D> &&
-          std::is_convertible_v<std::tuple<Args...>,
-              typename D::argument_types>) {
-    return static_cast<const typename Traits::meta_type*>(meta_)
-        ->template dispatch_meta<D>
-        ::dispatcher(ptr_, std::forward<Args>(args)...);
+          std::is_invocable_v<typename details::dispatch_traits<D>
+              ::overload_resolver, Args...>) {
+    constexpr auto OverloadIndex = decltype(typename details::dispatch_traits<D>
+        ::overload_resolver{}(std::forward<Args>(args)...))::value;
+    const auto& dispatchers =
+        static_cast<const typename Traits::meta_type*>(meta_)
+        ->template dispatch_meta<D>::dispatchers;
+    const auto& dispatcher = std::get<OverloadIndex>(dispatchers);
+    return dispatcher(ptr_, std::forward<Args>(args)...);
   }
 
  private:

--- a/proxy.h
+++ b/proxy.h
@@ -128,32 +128,33 @@ struct overload_traits<R(Args...)> : applicable_traits {
   }
 };
 
-template <class Os, class Is>
-struct overload_resolution_traits_impl;
+template <class Os, class Is> struct dispatch_traits_overload_resolution_impl;
 template <class Os, std::size_t... Is>
-struct overload_resolution_traits_impl<Os, std::index_sequence<Is...>> {
+struct dispatch_traits_overload_resolution_impl<
+    Os, std::index_sequence<Is...>> {
  private:
   template <std::size_t I>
   using single_resolver = typename overload_traits<std::tuple_element_t<I, Os>>
       ::template resolver<std::integral_constant<std::size_t, I>>;
-
- public:
   struct resolver : single_resolver<Is>...
       { using single_resolver<Is>::operator()...; };
-};
-template <class Os>
-struct overload_resolution_traits : overload_resolution_traits_impl<
-    Os, std::make_index_sequence<std::tuple_size_v<Os>>> {};
 
+ public:
+  template <class... Args>
+  static constexpr bool has_overload = std::is_invocable_v<resolver, Args...>;
+  template <class... Args>
+  static constexpr std::size_t overload_index =
+      std::invoke_result_t<resolver, Args...>::value;
+};
 template <class D, class Os>
 struct dispatch_traits_impl : inapplicable_traits {};
 template <class D, class... Os>
     requires(sizeof...(Os) > 0u && (overload_traits<Os>::applicable && ...))
-struct dispatch_traits_impl<D, std::tuple<Os...>> : applicable_traits {
+struct dispatch_traits_impl<D, std::tuple<Os...>> : applicable_traits,
+    dispatch_traits_overload_resolution_impl<std::tuple<Os...>,
+        std::make_index_sequence<sizeof...(Os)>> {
   using dispatcher_types =
       std::tuple<typename overload_traits<Os>::dispatcher_type...>;
-  using overload_resolver =
-      typename overload_resolution_traits<std::tuple<Os...>>::resolver;
 
   template <class T>
   static constexpr bool applicable_operand =
@@ -281,9 +282,9 @@ struct facade_traits_impl<F, std::tuple<Ds...>> : applicable_traits {
 template <class F> struct facade_traits : facade_traits_impl<
     F, typename flattening_traits<typename F::dispatch_types>::type> {};
 
-template <class T, class U> struct dependent_traits { using type = T; };
-template <class T, class U>
-using dependent_t = typename dependent_traits<T, U>::type;
+template <class T, class...> struct dependent_traits { using type = T; };
+template <class T, class... U>
+using dependent_t = typename dependent_traits<T, U...>::type;
 
 }  // namespace details
 
@@ -297,6 +298,7 @@ template <class F> requires(details::basic_facade_traits<F>::applicable)
 class proxy {
   using BasicTraits = details::basic_facade_traits<F>;
   using Traits = details::facade_traits<F>;
+  using DefaultDispatch = typename BasicTraits::default_dispatch;
 
   template <class P, class... Args>
   static constexpr bool HasNothrowPolyConstructor = std::conditional_t<
@@ -476,20 +478,26 @@ class proxy {
     initialize<P>(il, std::forward<Args>(args)...);
     return *reinterpret_cast<P*>(ptr_);
   }
-  template <class D = typename BasicTraits::default_dispatch, class... Args>
+  template <class D = DefaultDispatch, class... Args>
   decltype(auto) invoke(Args&&... args) const
-      requires(details::dependent_t<Traits, D>::applicable &&
-          BasicTraits::template has_dispatch<D> &&
-          std::is_invocable_v<typename details::dispatch_traits<D>
-              ::overload_resolver, Args...>) {
-    constexpr auto OverloadIndex = decltype(typename details::dispatch_traits<D>
-        ::overload_resolver{}(std::forward<Args>(args)...))::value;
-    const auto& dispatchers =
-        static_cast<const typename Traits::meta_type*>(meta_)
-        ->template dispatch_meta<D>::dispatchers;
+      requires(BasicTraits::template has_dispatch<D> &&
+          details::dependent_t<Traits, Args...>::applicable &&
+          details::dispatch_traits<D>::template has_overload<Args...>) {
+    constexpr std::size_t OverloadIndex =
+        details::dispatch_traits<D>::template overload_index<Args...>;
+    const auto& dispatchers = static_cast<const typename Traits::meta_type*>(
+        meta_)->template dispatch_meta<D>::dispatchers;
     const auto& dispatcher = std::get<OverloadIndex>(dispatchers);
     return dispatcher(ptr_, std::forward<Args>(args)...);
   }
+
+  template <class... Args>
+  decltype(auto) operator()(Args&&... args) const
+      requires(!std::is_void_v<DefaultDispatch> &&
+          details::dependent_t<Traits, Args...>::applicable &&
+          details::dispatch_traits<DefaultDispatch>
+              ::template has_overload<Args...>)
+      { return invoke(std::forward<Args>(args)...); }
 
  private:
   template <class P, class... Args>

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -6,14 +6,12 @@
 #include <proxy/proxy.h>
 
 struct at : pro::dispatch<std::string(int)> {
-  template <class T>
-  auto operator()(const T& self, int key) { return self.at(key); }
+  auto operator()(const auto& self, int key) { return self.at(key); }
 };
-
 struct resource_dictionary : pro::facade<at> {};
 
 void demo_print(pro::proxy<resource_dictionary> dictionary) {
-  std::cout << dictionary.invoke<at>(1) << std::endl;
+  std::cout << dictionary(1) << std::endl;
 }
 
 int main() {

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -5,20 +5,21 @@
 #include <list>
 #include <ranges>
 #include <string>
+#include <typeindex>
+#include <typeinfo>
 #include <vector>
 #include "proxy.h"
 
 namespace {
 
-template <class> struct Call;
-template <class R, class... Args>
-struct Call<R(Args...)> : pro::dispatch<R(Args...)> {
-  template <class T>
-  R operator()(T& self, Args&&... args)
+template <class... Os>
+struct Call : pro::dispatch<std::tuple<Os...>> {
+  template <class T, class... Args> requires(std::is_invocable_v<T, Args...>)
+  decltype(auto) operator()(T& self, Args&&... args)
       { return self(std::forward<Args>(args)...); }
 };
-template <class T>
-struct CallableFacade : pro::facade<Call<T>> {};
+template <class... Os>
+struct CallableFacade : pro::facade<Call<Os...>> {};
 
 struct GetSize : pro::dispatch<std::size_t(), std::ranges::size> {};
 
@@ -27,7 +28,7 @@ struct ForEach : pro::dispatch<void(pro::proxy<CallableFacade<void(T&)>>)> {
   template <class U>
   void operator()(U& self, pro::proxy<CallableFacade<void(T&)>>&& func) {
     for (auto& value : self) {
-      func.invoke(value);
+      func(value);
     }
   }
 };
@@ -47,13 +48,10 @@ struct Append : pro::dispatch<pro::proxy<ContainerFacade<T>>(T)> {
 };
 
 template <class F, class D, class... Args>
-concept InvocableWithDispatch = requires(pro::proxy<F> p, Args... args) {
-  { p.template invoke<D>(std::forward<Args>(args)...) };
-};
+concept InvocableWithDispatch = requires(pro::proxy<F> p, Args... args)
+    { { p.template invoke<D>(std::forward<Args>(args)...) }; };
 template <class F, class... Args>
-concept InvocableWithoutDispatch = requires(pro::proxy<F> p, Args... args) {
-  { p.invoke(std::forward<Args>(args)...) };
-};
+concept InvocableWithoutDispatch = std::is_invocable_v<pro::proxy<F>, Args...>;
 
 // Static assertions for a facade of a single dispatch
 static_assert(InvocableWithDispatch<CallableFacade<int(double)>, Call<int(double)>, double>);
@@ -67,6 +65,10 @@ static_assert(InvocableWithDispatch<IterableFacade<int>, GetSize>);
 static_assert(!InvocableWithDispatch<IterableFacade<int>, ForEach<int>, pro::proxy<CallableFacade<void(double&)>>>);  // Wrong arguments
 static_assert(!InvocableWithDispatch<IterableFacade<int>, Append<int>>);  // Wrong dispatch
 static_assert(!InvocableWithoutDispatch<IterableFacade<int>>);  // Invoking without specifying a dispatch
+
+template <class... Args>
+std::vector<std::type_index> GetTypeIndices()
+    { return {std::type_index{typeid(Args)}...}; }
 
 }  // namespace
 
@@ -144,4 +146,24 @@ TEST(ProxyInvocationTests, TestRecursiveDefinition) {
   sum = 0;
   p.invoke<ForEach<int>>(&accumulate_sum);
   ASSERT_EQ(sum, 21);
+}
+
+TEST(ProxyInvocationTests, TestOverloadResolution) {
+  struct TestFacade : CallableFacade<void(int), void(double), void(char*),
+      void(const char*), void(std::string, int)> {};
+  std::vector<std::type_index> side_effect;
+  auto p = pro::make_proxy<TestFacade>([&](auto&&... args)
+      { side_effect = GetTypeIndices<std::decay_t<decltype(args)>...>(); });
+  p(123);
+  ASSERT_EQ(side_effect, GetTypeIndices<int>());
+  p(1.23);
+  ASSERT_EQ(side_effect, GetTypeIndices<double>());
+  char foo[2];
+  p(foo);
+  ASSERT_EQ(side_effect, GetTypeIndices<char*>());
+  p("lalala");
+  ASSERT_EQ(side_effect, GetTypeIndices<const char*>());
+  p("lalala", 0);
+  ASSERT_EQ(side_effect, (GetTypeIndices<std::string, int>()));
+  ASSERT_FALSE((std::is_invocable_v<decltype(p), std::vector<int>>));
 }

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -13,7 +13,7 @@
 namespace {
 
 template <class... Os>
-struct Call : pro::dispatch<std::tuple<Os...>> {
+struct Call : pro::dispatch<Os...> {
   template <class T, class... Args> requires(std::is_invocable_v<T, Args...>)
   decltype(auto) operator()(T& self, Args&&... args)
       { return self(std::forward<Args>(args)...); }
@@ -21,7 +21,7 @@ struct Call : pro::dispatch<std::tuple<Os...>> {
 template <class... Os>
 struct CallableFacade : pro::facade<Call<Os...>> {};
 
-struct GetSize : pro::dispatch<std::size_t(), std::ranges::size> {};
+struct GetSize : pro::dispatch_adaptor<std::ranges::size, std::size_t()> {};
 
 template <class T>
 struct ForEach : pro::dispatch<void(pro::proxy<CallableFacade<void(T&)>>)> {


### PR DESCRIPTION
Overloading is a widely used paradigm that helps reducing the effort of naming of abstraction. However, it is not supported in the existing implementation of `proxy`. This PR aims to add this capability inspired by #43. After this change, overloading with different signatures becomes available in a single dispatch. An `operator()` was also added to `proxy` to simplify the invocation syntax when only one `dispatch` is specified. Unit test cases are updated accordingly to cover this change. Documentations will be updated later.

BREAKING CHANGE: `pro::dispatch` no longer supports adaption with CPO. This feature has been moved to another class template `pro::dispatch_adaptor`. `pro::dispatch<std::size_t(), std::ranges::size>` was a valid type before this change but not anymore. The equivalent type has become `pro::dispatch_adaptor<std::ranges::size, std::size_t()>` with this change.

The syntax to define a dispatch with single overload is the same as before:

```cpp
struct foo : pro::dispatch<int(int)> {
  auto operator()(const auto& self, int val) { return self.foo(val); }
};
```

The syntax to define a dispatch with multiple overloads is similar:

```cpp
struct foo : pro::dispatch<int(int), double(double)> {
  auto operator()(const auto& self, auto val) { return self.foo(val); }
};
```

See the updated unit test cases for more details.