### PR TITLE
Add macros to simplify syntax of creating dispatches and facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ The "proxy" is a single-header, cross-platform C++ library that Microsoft uses t
 
 The "proxy" is a header-only C++20 library. Once you set the language level of your compiler not earlier than C++20 and get the header file ([proxy.h](proxy.h)), you are all set. You can also install the library via [vcpkg](https://github.com/microsoft/vcpkg/), which is a C++ library manager invented by Microsoft, by searching for "proxy" (see [vcpkg.info](https://vcpkg.info/port/proxy)).
 
-All the facilities of the library are defined in namespace `pro`. The 3 major class templates are `dispatch`, `facade` and `proxy`. Here is a demo showing how to use this library to implement runtime polymorphism in a different way from the traditional inheritance-based approach:
+All the facilities of the library are defined in namespace `pro`. The 3 major class templates are `dispatch`, `facade` and `proxy`. Some macros are defined (currently not in the proposal of standardization) to facilitate definition of `dispatch`es and `facade`s. Here is a demo showing how to use this library to implement runtime polymorphism in a different way from the traditional inheritance-based approach:
 
 ```cpp
 // Abstraction
-struct Draw : pro::dispatch<void(std::ostream&)> {
-  void operator()(const auto& self, std::ostream& out) { self.Draw(out); }
-};
-struct Area : pro::dispatch<double()> {
-  double operator()(const auto& self) { return self.Area(); }
-};
-struct DrawableFacade : pro::facade<Draw, Area> {};
+
+DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
+DEFINE_MEMBER_DISPATCH(Area, Area, double());
+DEFINE_FACADE(DrawableFacade, Draw, Area);
 
 // Implementation
 class Rectangle {

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ The "proxy" is a header-only C++20 library. Once you set the language level of y
 All the facilities of the library are defined in namespace `pro`. The 3 major class templates are `dispatch`, `facade` and `proxy`. Some macros are defined (currently not in the proposal of standardization) to facilitate definition of `dispatch`es and `facade`s. Here is a demo showing how to use this library to implement runtime polymorphism in a different way from the traditional inheritance-based approach:
 
 ```cpp
-// Abstraction
+// Abstraction (poly is short for polymorphism)
+namespace poly {
 
 DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
 DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(DrawableFacade, Draw, Area);
+DEFINE_FACADE(Drawable, Draw, Area);
+
+}  // namespace poly
 
 // Implementation
 class Rectangle {
@@ -40,20 +43,20 @@ class Rectangle {
 };
 
 // Client - Consumer
-std::string PrintDrawableToString(pro::proxy<DrawableFacade> p) {
+std::string PrintDrawableToString(pro::proxy<poly::Drawable> p) {
   std::stringstream result;
   result << "shape = ";
-  p.invoke<Draw>(result);
-  result << ", area = " << p.invoke<Area>();
+  p.invoke<poly::Draw>(result);
+  result << ", area = " << p.invoke<poly::Area>();
   return std::move(result).str();
 }
 
 // Client - Producer
-pro::proxy<DrawableFacade> CreateRectangleAsDrawable(int width, int height) {
+pro::proxy<poly::Drawable> CreateRectangleAsDrawable(int width, int height) {
   Rectangle rect;
   rect.SetWidth(width);
   rect.SetHeight(height);
-  return pro::make_proxy<DrawableFacade>(rect);
+  return pro::make_proxy<poly::Drawable>(rect);
 }
 ```
 

--- a/proxy.h
+++ b/proxy.h
@@ -568,20 +568,22 @@ struct facade {
 // The following macros facilitate definition of dispatch and facade types
 #define DEFINE_MEMBER_DISPATCH(__NAME, __FUNC, ...) \
     struct __NAME : ::pro::dispatch<__VA_ARGS__> { \
-      template <class T, class... Args> \
-      decltype(auto) operator()(T&& value, Args&&... args) \
-          requires(requires{\
-              std::forward<T>(value).__FUNC(std::forward<Args>(args)...); }) { \
-        return std::forward<T>(value).__FUNC(std::forward<Args>(args)...); \
+      template <class __T, class... __Args> \
+      decltype(auto) operator()(__T&& __self, __Args&&... __args) \
+          requires(requires{ std::forward<__T>(__self) \
+              .__FUNC(std::forward<__Args>(__args)...); }) { \
+        return std::forward<__T>(__self) \
+            .__FUNC(std::forward<__Args>(__args)...); \
       } \
     }
 #define DEFINE_FREE_DISPATCH(__NAME, __FUNC, ...) \
     struct __NAME : ::pro::dispatch<__VA_ARGS__> { \
-      template <class T, class... Args> \
-      decltype(auto) operator()(T&& value, Args&&... args) \
-          requires(requires{\
-              __FUNC(std::forward<T>(value), std::forward<Args>(args)...); }) { \
-        return __FUNC(std::forward<T>(value), std::forward<Args>(args)...); \
+      template <class __T, class... __Args> \
+      decltype(auto) operator()(__T&& __self, __Args&&... __args) \
+          requires(requires{ __FUNC(std::forward<__T>(__self), \
+              std::forward<__Args>(__args)...); }) { \
+        return __FUNC(std::forward<__T>(__self), \
+            std::forward<__Args>(__args)...); \
       } \
     }
 

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -5,10 +5,8 @@
 
 #include <proxy/proxy.h>
 
-struct at : pro::dispatch<std::string(int)> {
-  auto operator()(const auto& self, int key) { return self.at(key); }
-};
-struct resource_dictionary : pro::facade<at> {};
+DEFINE_MEMBER_DISPATCH(at, at, std::string(int));
+DEFINE_FACADE(resource_dictionary, at);
 
 void demo_print(pro::proxy<resource_dictionary> dictionary) {
   std::cout << dictionary(1) << std::endl;

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -5,10 +5,14 @@
 
 #include <proxy/proxy.h>
 
-DEFINE_MEMBER_DISPATCH(at, at, std::string(int));
-DEFINE_FACADE(resource_dictionary, at);
+namespace poly {
 
-void demo_print(pro::proxy<resource_dictionary> dictionary) {
+DEFINE_MEMBER_DISPATCH(At, at, std::string(int));
+DEFINE_FACADE(Dictionary, At);
+
+}  // namespace poly
+
+void demo_print(pro::proxy<poly::Dictionary> dictionary) {
   std::cout << dictionary(1) << std::endl;
 }
 

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -13,9 +13,13 @@
 
 namespace {
 
+namespace poly {
+
 DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
 DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(DrawableFacade, Draw, Area);
+DEFINE_FACADE(Drawable, Draw, Area);
+
+}  // namespace poly
 
 class Rectangle {
  public:
@@ -46,11 +50,11 @@ class Point {
   constexpr double Area() const { return 0; }
 };
 
-std::string PrintDrawableToString(pro::proxy<DrawableFacade> p) {
+std::string PrintDrawableToString(pro::proxy<poly::Drawable> p) {
   std::stringstream result;
   result << std::fixed << std::setprecision(5) << "shape = ";
-  p.invoke<Draw>(result);
-  result << ", area = " << p.invoke<Area>();
+  p.invoke<poly::Draw>(result);
+  result << ", area = " << p.invoke<poly::Area>();
   return std::move(result).str();
 }
 
@@ -77,7 +81,7 @@ std::vector<std::string> ParseCommand(const std::string& s) {
   return result;
 }
 
-pro::proxy<DrawableFacade> MakeDrawableFromCommand(const std::string& s) {
+pro::proxy<poly::Drawable> MakeDrawableFromCommand(const std::string& s) {
   std::vector<std::string> parsed = ParseCommand(s);
   if (!parsed.empty()) {
     if (parsed[0u] == "Rectangle") {
@@ -96,7 +100,7 @@ pro::proxy<DrawableFacade> MakeDrawableFromCommand(const std::string& s) {
       if (parsed.size() == 2u) {
         Circle circle;
         circle.SetRadius(std::stod(parsed[1u]));
-        return pro::make_proxy<DrawableFacade>(circle);
+        return pro::make_proxy<poly::Drawable>(circle);
       }
     } else if (parsed[0u] == "Point") {
       if (parsed.size() == 1u) {
@@ -111,7 +115,7 @@ pro::proxy<DrawableFacade> MakeDrawableFromCommand(const std::string& s) {
 }  // namespace
 
 TEST(ProxyIntegrationTests, TestDrawable) {
-  pro::proxy<DrawableFacade> p = MakeDrawableFromCommand("Rectangle 2 3");
+  pro::proxy<poly::Drawable> p = MakeDrawableFromCommand("Rectangle 2 3");
   std::string s = PrintDrawableToString(std::move(p));
   ASSERT_EQ(s, "shape = {Rectangle: width = 2.00000, height = 3.00000}, area = 6.00000");
 

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -13,16 +13,9 @@
 
 namespace {
 
-struct Draw : pro::dispatch<void(std::ostream&)> {
-  template <class T>
-  void operator()(const T& self, std::ostream& out) { self.Draw(out); }
-};
-struct Area : pro::dispatch<double()> {
-  template <class T>
-  double operator()(const T& self) { return self.Area(); }
-};
-
-struct DrawableFacade : pro::facade<Draw, Area> {};
+DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
+DEFINE_MEMBER_DISPATCH(Area, Area, double());
+DEFINE_FACADE(DrawableFacade, Draw, Area);
 
 class Rectangle {
  public:

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-struct TestFacade : pro::facade<utils::ToString> {
+struct TestFacade : pro::facade<utils::poly::ToString> {
   static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
 };
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -80,14 +80,12 @@ class LifetimeTracker {
   std::vector<LifetimeOperation> ops_;
 };
 
-namespace details {
+namespace poly {
 
 using std::to_string;
 DEFINE_FREE_DISPATCH(ToString, to_string, std::string());
 
-} // namespace details
-
-using details::ToString;
+}  // namespace poly
 
 }  // namespace utils
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -80,13 +80,14 @@ class LifetimeTracker {
   std::vector<LifetimeOperation> ops_;
 };
 
-struct ToString : pro::dispatch<std::string()> {
-  template <class T>
-  std::string operator()(const T& self) {
-    using std::to_string;
-    return to_string(self);
-  }
-};
+namespace details {
+
+using std::to_string;
+DEFINE_FREE_DISPATCH(ToString, to_string, std::string());
+
+} // namespace details
+
+using details::ToString;
 
 }  // namespace utils
 


### PR DESCRIPTION
**Changes**

- Added macros `DEFINE_MEMBER_DISPATCH`, `DEFINE_FREE_DISPATCH`, `DEFINE_FACADE`, and `DEFINE_COPYABLE_FACADE`. These macros are not intended to be included in the proposal of standardization, but should make the library easier to use before the static reflection standards are stabilized.
- Removed class template `pro::dispatch_adapter` since it is shadowed by the macros.
- Fixed a bug: When the required return type of an overload is `void`, but the concrete return type of a dispatch is not `void`, the code won't compile.
- Updated unit tests and sample code accordingly.

**Quick glance**

Before:

```cpp

struct Draw : pro::dispatch<void(std::ostream&)> {
  void operator()(const auto& self, std::ostream& out) { self.Draw(out); }
};
struct Area : pro::dispatch<double()> {
  double operator()(const auto& self) { return self.Area(); }
};
struct DrawableFacade : pro::facade<Draw, Area> {};
```

After:

```cpp
DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
DEFINE_MEMBER_DISPATCH(Area, Area, double());
DEFINE_FACADE(DrawableFacade, Draw, Area);
```
