### PR TITLE
Revise pointer requirements

### DIFF
--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -14,7 +14,7 @@ struct MockPtr {
   MockPtr(const MockPtr&) noexcept requires(kTrivial) = default;
   MockPtr(MockPtr&&) noexcept requires(kNothrowRelocatable && !kTrivial) {}
   MockPtr(MockPtr&&) noexcept requires(kTrivial) = default;
-  const MockPtr& operator*() const noexcept { return *this; }
+  const MockPtr* operator->() const noexcept { return this; }
 
   alignas(kAlignment) char dummy_[kSize];
 };

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -54,7 +54,7 @@ class LifetimeTracker {
           id_(rhs.host_->AllocateId(LifetimeOperationType::kMoveConstruction)),
           host_(rhs.host_) {}
     ~Session() { host_->ops_.emplace_back(id_, LifetimeOperationType::kDestruction); }
-    const Session& operator*() const { return *this; }
+    const Session* operator->() const { return this; }
     friend std::string to_string(const Session& self) { return "Session " + std::to_string(self.id_); }
 
    private:


### PR DESCRIPTION
This change revised requirements of pointers with `std::to_address()` function template in C++20 to avoid inventing another "pointer requirements". No functional change.

Before: Concept `proxiable` requires `*p` be well-formed, and for each dispatch type `D` defined by `typename F::dispatch_types`, `D` meets the `Dispatch` requirements of type `decltype(*p)`.
After: Concept `proxiable` requires `std::address_of(p)` be well-formed, and for each dispatch type `D` defined by `typename F::dispatch_types`, `D` meets the `Dispatch` requirements of type `decltype(*std::address_of(p))`.

The definition of class templates `pro::details::sbo_ptr` and `pro::details::deep_ptr` are updated accordingly.