### PR TITLE
Revise the semantics of facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Proxy: Redefine Polymorphism in C++
+# Proxy: Polymorphism in C++ Redefined
 
 [![Proxy-CI](https://github.com/microsoft/proxy/actions/workflows/pipeline-ci.yml/badge.svg)](https://github.com/microsoft/proxy/actions/workflows/pipeline-ci.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Proxy: Easy Polymorphism in C++
+# Proxy: Redefine Polymorphism in C++
 
 [![Proxy-CI](https://github.com/microsoft/proxy/actions/workflows/pipeline-ci.yml/badge.svg)](https://github.com/microsoft/proxy/actions/workflows/pipeline-ci.yml)
 
@@ -10,13 +10,15 @@ Have you tried other polymorphic programming libraries in C++ but found them def
 
 If so, this library is for you. 😉
 
+For decades, object-based virtual table has been a de facto implementation of runtime polymorphism in many (compiled) programming languages. There are many drawbacks in this mechanism, including life management (because each object may have different size and ownership) and reflection (because it is hard to balance between usability and memory allocation). To workaround these drawbacks, some languages like Java or C# choose to sacrifice performance by introducing GC to facilitate lifetime management, and JIT-compile the source code at runtime to generate full metadata. We improved the theory and implemented as a C++ library without sacrificing performance, proposed to merge into the C++ standard.
+
 The "proxy" is a single-header, cross-platform C++ library that Microsoft uses to make runtime polymorphism easier to implement and faster. Please find the design details at https://wg21.link/p0957.
 
 ## Quick start
 
 The "proxy" is a header-only C++20 library. Once you set the language level of your compiler not earlier than C++20 and get the header file ([proxy.h](proxy.h)), you are all set. You can also install the library via [vcpkg](https://github.com/microsoft/vcpkg/), which is a C++ library manager invented by Microsoft, by searching for "proxy" (see [vcpkg.info](https://vcpkg.info/port/proxy)).
 
-All the facilities of the library are defined in namespace `pro`. The 3 major class templates are `dispatch`, `facade` and `proxy`. Some macros are defined (currently not in the proposal of standardization) to facilitate definition of `dispatch`es and `facade`s. Here is a demo showing how to use this library to implement runtime polymorphism in a different way from the traditional inheritance-based approach:
+The majority of the library is defined in namespace `pro`. Some macros are provided (currently not included in the proposal of standardization) to simplify the definiton of `proxy` prior to C++26. Here is a demo showing how to use this library to implement runtime polymorphism in a different way from the traditional inheritance-based approach:
 
 ```cpp
 // Abstraction (poly is short for polymorphism)
@@ -24,7 +26,7 @@ namespace poly {
 
 DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
 DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(Drawable, Draw, Area);
+DEFINE_FACADE(Drawable, MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly
 
@@ -57,6 +59,46 @@ pro::proxy<poly::Drawable> CreateRectangleAsDrawable(int width, int height) {
   rect.SetWidth(width);
   rect.SetHeight(height);
   return pro::make_proxy<poly::Drawable>(rect);
+}
+```
+
+Here is another demo showing how to define overloads in a dispatch. Note that `.invoke<>` can be ommitted when only 1 dispatch is defined in a facade:
+
+```cpp
+// Abstraction (poly is short for polymorphism)
+namespace poly {
+
+DEFINE_MEMBER_DISPATCH(Log, Log,
+    void(const char*), void(const char*, const std::exception&));
+DEFINE_FACADE(Logger, Log);
+
+}  // namespace poly
+
+// Client - Consumer
+void MyVerboseFunction(pro::proxy<poly::Logger> logger) {
+  logger("hello");
+  try {
+    throw std::runtime_error{"runtime error!"};
+  } catch (const std::exception& e) {
+    logger("world", e);
+  }
+}
+
+// Implementation
+struct MyLogger {
+  void Log(const char* s) {
+    printf("[INFO] %s\n", s);
+  }
+  void Log(const char* s, const std::exception& e) {
+    printf("[ERROR] %s (exception info: %s)\n", s, e.what());
+  }
+};
+
+// Client - Producer
+int main() {
+  MyLogger logger;
+  MyVerboseFunction(&logger);
+  return 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The majority of the library is defined in namespace `pro`. Some macros are provi
 // Abstraction (poly is short for polymorphism)
 namespace poly {
 
-DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
-DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(Drawable, MAKE_DISPATCH_PACK(Draw, Area));
+PRO_DEF_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
+PRO_DEF_MEMBER_DISPATCH(Area, Area, double());
+PRO_DEF_FACADE(Drawable, PRO_MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly
 
@@ -68,9 +68,9 @@ Here is another demo showing how to define overloads in a dispatch. Note that `.
 // Abstraction (poly is short for polymorphism)
 namespace poly {
 
-DEFINE_MEMBER_DISPATCH(Log, Log,
+PRO_DEF_MEMBER_DISPATCH(Log, Log,
     void(const char*), void(const char*, const std::exception&));
-DEFINE_FACADE(Logger, Log);
+PRO_DEF_FACADE(Logger, Log);
 
 }  // namespace poly
 

--- a/proxy.h
+++ b/proxy.h
@@ -584,7 +584,7 @@ proxy<F> make_proxy(T&& value) {
 }
 
 // The following types and macros aim to simplify definition of dispatch and
-// facade types before C++26
+// facade types prior to C++26
 namespace helper {
 
 template <class D = std::tuple<>, proxy_pointer_constraints C =
@@ -598,7 +598,8 @@ struct facade_prototype {
 }  // namespace helper
 
 }  // namespace pro
-#define DEFINE_MEMBER_DISPATCH(__NAME, __FUNC, ...) \
+
+#define PRO_DEF_MEMBER_DISPATCH(__NAME, __FUNC, ...) \
     struct __NAME { \
       using overload_types = std::tuple<__VA_ARGS__>;\
       template <class __T, class... __Args> \
@@ -609,7 +610,7 @@ struct facade_prototype {
             .__FUNC(std::forward<__Args>(__args)...); \
       } \
     }
-#define DEFINE_FREE_DISPATCH(__NAME, __FUNC, ...) \
+#define PRO_DEF_FREE_DISPATCH(__NAME, __FUNC, ...) \
     struct __NAME { \
       using overload_types = std::tuple<__VA_ARGS__>;\
       template <class __T, class... __Args> \
@@ -620,8 +621,8 @@ struct facade_prototype {
             std::forward<__Args>(__args)...); \
       } \
     }
-#define MAKE_DISPATCH_PACK(...) std::tuple<__VA_ARGS__>
-#define DEFINE_FACADE(__NAME, ...) \
+#define PRO_MAKE_DISPATCH_PACK(...) std::tuple<__VA_ARGS__>
+#define PRO_DEF_FACADE(__NAME, ...) \
     struct __NAME : ::pro::helper::facade_prototype<__VA_ARGS__> {}
 
 #endif  // _MSFT_PROXY_

--- a/proxy.h
+++ b/proxy.h
@@ -601,15 +601,15 @@ struct facade_prototype {
 
 }  // namespace pro
 
-#define PRO_DEF_MEMBER_DISPATCH(__NAME, __FUNC, ...) \
+#define PRO_DEF_MEMBER_DISPATCH(__NAME, ...) \
     struct __NAME { \
       using overload_types = std::tuple<__VA_ARGS__>;\
       template <class __T, class... __Args> \
       decltype(auto) operator()(__T&& __self, __Args&&... __args) \
           requires(requires{ std::forward<__T>(__self) \
-              .__FUNC(std::forward<__Args>(__args)...); }) { \
+              .__NAME(std::forward<__Args>(__args)...); }) { \
         return std::forward<__T>(__self) \
-            .__FUNC(std::forward<__Args>(__args)...); \
+            .__NAME(std::forward<__Args>(__args)...); \
       } \
     }
 #define PRO_DEF_FREE_DISPATCH(__NAME, __FUNC, ...) \

--- a/proxy.h
+++ b/proxy.h
@@ -16,6 +16,35 @@ namespace pro {
 
 enum class constraint_level { none, nontrivial, nothrow, trivial };
 
+struct proxy_pointer_constraints {
+  std::size_t maximum_size;
+  std::size_t maximum_alignment;
+  constraint_level minimum_copyability;
+  constraint_level minimum_relocatability;
+  constraint_level minimum_destructibility;
+};
+constexpr proxy_pointer_constraints relocatable_pointer_constraints{
+  .maximum_size = sizeof(void*) * 2u,
+  .maximum_alignment = alignof(void*),
+  .minimum_copyability = constraint_level::none,
+  .minimum_relocatability = constraint_level::nothrow,
+  .minimum_destructibility = constraint_level::nothrow,
+};
+constexpr proxy_pointer_constraints copyable_pointer_constraints{
+  .maximum_size = sizeof(void*) * 2u,
+  .maximum_alignment = alignof(void*),
+  .minimum_copyability = constraint_level::nontrivial,
+  .minimum_relocatability = constraint_level::nothrow,
+  .minimum_destructibility = constraint_level::nothrow,
+};
+constexpr proxy_pointer_constraints trivial_pointer_constraints{
+  .maximum_size = sizeof(void*),
+  .maximum_alignment = alignof(void*),
+  .minimum_copyability = constraint_level::trivial,
+  .minimum_relocatability = constraint_level::trivial,
+  .minimum_destructibility = constraint_level::trivial,
+};
+
 namespace details {
 
 struct applicable_traits { static constexpr bool applicable = true; };
@@ -153,8 +182,8 @@ template <class D> requires(requires {
       typename D::overload_types;
       { D{} };
     })
-struct dispatch_traits<D> : dispatch_traits_impl<
-    D, typename flattening_traits<typename D::overload_types>::type> {};
+struct dispatch_traits<D>
+    : dispatch_traits_impl<D, typename D::overload_types> {};
 
 template <class D>
 struct dispatch_meta {
@@ -217,11 +246,14 @@ template <> struct facade_meta_traits<> { using type = facade_meta<>; };
 
 template <class F, class Ds> struct basic_facade_traits_impl;
 template <class F, class... Ds>
-struct basic_facade_traits_impl<F, std::tuple<Ds...>> : applicable_traits {
+struct basic_facade_traits_impl<F, std::tuple<Ds...>> {
   using meta_type = typename facade_meta_traits<
-      conditional_meta_tag<F::minimum_copyability, copy_meta>,
-      conditional_meta_tag<F::minimum_relocatability, relocation_meta>,
-      conditional_meta_tag<F::minimum_destructibility, destruction_meta>,
+      conditional_meta_tag<
+          F::pointer_constraints.minimum_copyability, copy_meta>,
+      conditional_meta_tag<
+          F::pointer_constraints.minimum_relocatability, relocation_meta>,
+      conditional_meta_tag<
+          F::pointer_constraints.minimum_destructibility, destruction_meta>,
       conditional_meta_tag<std::is_void_v<typename F::reflection_type> ?
           constraint_level::none : constraint_level::nothrow,
           typename F::reflection_type>>::type;
@@ -230,19 +262,8 @@ struct basic_facade_traits_impl<F, std::tuple<Ds...>> : applicable_traits {
   template <class D>
   static constexpr bool has_dispatch = contains_traits<D, Ds...>::applicable;
 };
-template <class F> struct basic_facade_traits : inapplicable_traits {};
-template <class F> requires(requires {
-      typename F::dispatch_types;
-      typename F::reflection_type;
-      typename std::integral_constant<std::size_t, F::maximum_size>;
-      typename std::integral_constant<std::size_t, F::maximum_alignment>;
-      typename std::integral_constant<constraint_level, F::minimum_copyability>;
-      typename std::integral_constant<
-          constraint_level, F::minimum_relocatability>;
-      typename std::integral_constant<
-          constraint_level, F::minimum_destructibility>;
-    })
-struct basic_facade_traits<F> : basic_facade_traits_impl<
+template <class F>
+struct basic_facade_traits : basic_facade_traits_impl<
     F, typename flattening_traits<typename F::dispatch_types>::type> {};
 
 template <class F, class Ds>
@@ -254,10 +275,11 @@ struct facade_traits_impl<F, std::tuple<Ds...>> : applicable_traits {
 
   template <class P>
   static constexpr bool applicable_pointer =
-      sizeof(P) <= F::maximum_size && alignof(P) <= F::maximum_alignment &&
-      has_copyability<P>(F::minimum_copyability) &&
-      has_relocatability<P>(F::minimum_relocatability) &&
-      has_destructibility<P>(F::minimum_destructibility) &&
+      sizeof(P) <= F::pointer_constraints.maximum_size &&
+      alignof(P) <= F::pointer_constraints.maximum_alignment &&
+      has_copyability<P>(F::pointer_constraints.minimum_copyability) &&
+      has_relocatability<P>(F::pointer_constraints.minimum_relocatability) &&
+      has_destructibility<P>(F::pointer_constraints.minimum_destructibility) &&
       (dispatch_traits<Ds>::template applicable_pointer<P> && ...) &&
       (std::is_void_v<typename F::reflection_type> || std::is_constructible_v<
           typename F::reflection_type, std::in_place_type_t<P>>);
@@ -272,13 +294,20 @@ using dependent_t = typename dependent_traits<T, Us...>::type;
 
 }  // namespace details
 
+template <class F>
+concept facade = requires {
+  typename F::dispatch_types;
+  typename std::integral_constant<
+      proxy_pointer_constraints, F::pointer_constraints>;
+  typename F::reflection_type;
+};
+
 template <class P, class F>
-concept proxiable = details::is_address_deducible<const P> &&
-    details::basic_facade_traits<F>::applicable &&
+concept proxiable = facade<F> && details::is_address_deducible<const P> &&
     details::facade_traits<F>::applicable &&
     details::facade_traits<F>::template applicable_pointer<P>;
 
-template <class F> requires(details::basic_facade_traits<F>::applicable)
+template <facade F>
 class proxy {
   using BasicTraits = details::basic_facade_traits<F>;
   using Traits = details::facade_traits<F>;
@@ -293,21 +322,21 @@ class proxy {
       proxiable<P, F>, std::is_constructible<P, Args...>,
           std::false_type>::value;
   static constexpr bool HasTrivialCopyConstructor =
-      F::minimum_copyability == constraint_level::trivial;
+      F::pointer_constraints.minimum_copyability == constraint_level::trivial;
   static constexpr bool HasNothrowCopyConstructor =
-      F::minimum_copyability >= constraint_level::nothrow;
-  static constexpr bool HasCopyConstructor =
-      F::minimum_copyability >= constraint_level::nontrivial;
-  static constexpr bool HasNothrowMoveConstructor =
-      F::minimum_relocatability >= constraint_level::nothrow;
-  static constexpr bool HasMoveConstructor =
-      F::minimum_relocatability >= constraint_level::nontrivial;
-  static constexpr bool HasTrivialDestructor =
-      F::minimum_destructibility == constraint_level::trivial;
-  static constexpr bool HasNothrowDestructor =
-      F::minimum_destructibility >= constraint_level::nothrow;
-  static constexpr bool HasDestructor =
-      F::minimum_destructibility >= constraint_level::nontrivial;
+      F::pointer_constraints.minimum_copyability >= constraint_level::nothrow;
+  static constexpr bool HasCopyConstructor = F::pointer_constraints
+      .minimum_copyability >= constraint_level::nontrivial;
+  static constexpr bool HasNothrowMoveConstructor = F::pointer_constraints
+      .minimum_relocatability >= constraint_level::nothrow;
+  static constexpr bool HasMoveConstructor = F::pointer_constraints
+      .minimum_relocatability >= constraint_level::nontrivial;
+  static constexpr bool HasTrivialDestructor = F::pointer_constraints
+      .minimum_destructibility == constraint_level::trivial;
+  static constexpr bool HasNothrowDestructor = F::pointer_constraints
+      .minimum_destructibility >= constraint_level::nothrow;
+  static constexpr bool HasDestructor = F::pointer_constraints
+      .minimum_destructibility >= constraint_level::nontrivial;
   template <class P, class... Args>
   static constexpr bool HasNothrowPolyAssignment =
       HasNothrowPolyConstructor<P, Args...> && HasNothrowDestructor;
@@ -341,8 +370,9 @@ class proxy {
   proxy(proxy&& rhs) noexcept(HasNothrowMoveConstructor)
       requires(HasMoveConstructor) {
     if (rhs.meta_ != nullptr) {
-      if constexpr (F::minimum_relocatability == constraint_level::trivial) {
-        memcpy(ptr_, rhs.ptr_, F::maximum_size);
+      if constexpr (F::pointer_constraints.minimum_relocatability ==
+          constraint_level::trivial) {
+        memcpy(ptr_, rhs.ptr_, F::pointer_constraints.maximum_size);
       } else {
         rhs.meta_->relocate(ptr_, rhs.ptr_);
       }
@@ -428,7 +458,8 @@ class proxy {
       { this->~proxy(); meta_ = nullptr; }
   void swap(proxy& rhs) noexcept(HasNothrowMoveConstructor)
       requires(HasMoveConstructor) {
-    if constexpr (F::minimum_relocatability == constraint_level::trivial) {
+    if constexpr (F::pointer_constraints.minimum_relocatability ==
+        constraint_level::trivial) {
       std::swap(meta_, rhs.meta_);
       std::swap(ptr_, rhs.ptr);
     } else {
@@ -491,7 +522,8 @@ class proxy {
   }
 
   const typename BasicTraits::meta_type* meta_;
-  alignas(F::maximum_alignment) char ptr_[F::maximum_size];
+  alignas(F::pointer_constraints.maximum_alignment)
+      char ptr_[F::pointer_constraints.maximum_size];
 };
 
 namespace details {
@@ -551,26 +583,24 @@ proxy<F> make_proxy(T&& value) {
   return details::make_proxy_impl<F, std::decay_t<T>>(std::forward<T>(value));
 }
 
-template <class... Os>
-struct dispatch { using overload_types = std::tuple<Os...>; };
+// The following types and macros aim to simplify definition of dispatch and
+// facade types before C++26
+namespace helper {
 
-template <class... Ds>
-struct facade {
-  using dispatch_types = std::tuple<Ds...>;
-  using reflection_type = void;
-  static constexpr std::size_t maximum_size = sizeof(void*) * 2u;
-  static constexpr std::size_t maximum_alignment = alignof(void*);
-  static constexpr auto minimum_copyability = constraint_level::none;
-  static constexpr auto minimum_relocatability = constraint_level::nothrow;
-  static constexpr auto minimum_destructibility = constraint_level::nothrow;
-  facade() = delete;
+template <class D = std::tuple<>, proxy_pointer_constraints C =
+    relocatable_pointer_constraints, class R = void>
+struct facade_prototype {
+  using dispatch_types = D;
+  static constexpr proxy_pointer_constraints pointer_constraints = C;
+  using reflection_type = R;
 };
 
-}  // namespace pro
+}  // namespace helper
 
-// The following macros facilitate definition of dispatch and facade types
+}  // namespace pro
 #define DEFINE_MEMBER_DISPATCH(__NAME, __FUNC, ...) \
-    struct __NAME : ::pro::dispatch<__VA_ARGS__> { \
+    struct __NAME { \
+      using overload_types = std::tuple<__VA_ARGS__>;\
       template <class __T, class... __Args> \
       decltype(auto) operator()(__T&& __self, __Args&&... __args) \
           requires(requires{ std::forward<__T>(__self) \
@@ -580,7 +610,8 @@ struct facade {
       } \
     }
 #define DEFINE_FREE_DISPATCH(__NAME, __FUNC, ...) \
-    struct __NAME : ::pro::dispatch<__VA_ARGS__> { \
+    struct __NAME { \
+      using overload_types = std::tuple<__VA_ARGS__>;\
       template <class __T, class... __Args> \
       decltype(auto) operator()(__T&& __self, __Args&&... __args) \
           requires(requires{ __FUNC(std::forward<__T>(__self), \
@@ -589,13 +620,8 @@ struct facade {
             std::forward<__Args>(__args)...); \
       } \
     }
-
+#define MAKE_DISPATCH_PACK(...) std::tuple<__VA_ARGS__>
 #define DEFINE_FACADE(__NAME, ...) \
-    struct __NAME : ::pro::facade<__VA_ARGS__> {}
-#define DEFINE_COPYABLE_FACADE(__NAME, ...) \
-    struct __NAME : ::pro::facade<__VA_ARGS__> { \
-      static constexpr auto minimum_copyability = \
-          pro::constraint_level::nontrivial; \
-    }
+    struct __NAME : ::pro::helper::facade_prototype<__VA_ARGS__> {}
 
 #endif  // _MSFT_PROXY_

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -7,8 +7,8 @@
 
 namespace poly {
 
-DEFINE_MEMBER_DISPATCH(At, at, std::string(int));
-DEFINE_FACADE(Dictionary, At);
+PRO_DEF_MEMBER_DISPATCH(At, at, std::string(int));
+PRO_DEF_FACADE(Dictionary, At);
 
 }  // namespace poly
 

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -7,8 +7,8 @@
 
 namespace poly {
 
-PRO_DEF_MEMBER_DISPATCH(At, at, std::string(int));
-PRO_DEF_FACADE(Dictionary, At);
+PRO_DEF_MEMBER_DISPATCH(at, std::string(int));
+PRO_DEF_FACADE(Dictionary, at);
 
 }  // namespace poly
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -21,14 +21,14 @@ struct SboObserver {
   bool SboEnabled;
 };
 
-DEFINE_FACADE(TestSmallStringable, utils::poly::ToString, pro::proxy_pointer_constraints{
+PRO_DEF_FACADE(TestSmallStringable, utils::poly::ToString, pro::proxy_pointer_constraints{
     .maximum_size = sizeof(void*),
     .maximum_alignment = alignof(void*),
     .minimum_copyability = pro::constraint_level::nontrivial,
     .minimum_relocatability = pro::constraint_level::nothrow,
     .minimum_destructibility = pro::constraint_level::nothrow,
   }, SboObserver);
-DEFINE_FACADE(TestLargeStringable, utils::poly::ToString, pro::copyable_pointer_constraints, SboObserver);
+PRO_DEF_FACADE(TestLargeStringable, utils::poly::ToString, pro::copyable_pointer_constraints, SboObserver);
 
 }  // namespace poly
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -21,15 +21,14 @@ struct SboObserver {
   bool SboEnabled;
 };
 
-struct TestSmallStringable : pro::facade<utils::poly::ToString> {
-  using reflection_type = SboObserver;
-  static constexpr std::size_t maximum_size = sizeof(void*);
-  static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
-};
-struct TestLargeStringable : pro::facade<utils::poly::ToString> {
-  using reflection_type = SboObserver;
-  static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
-};
+DEFINE_FACADE(TestSmallStringable, utils::poly::ToString, pro::proxy_pointer_constraints{
+    .maximum_size = sizeof(void*),
+    .maximum_alignment = alignof(void*),
+    .minimum_copyability = pro::constraint_level::nontrivial,
+    .minimum_relocatability = pro::constraint_level::nothrow,
+    .minimum_destructibility = pro::constraint_level::nothrow,
+  }, SboObserver);
+DEFINE_FACADE(TestLargeStringable, utils::poly::ToString, pro::copyable_pointer_constraints, SboObserver);
 
 }  // namespace poly
 

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -15,9 +15,9 @@ namespace {
 
 namespace poly {
 
-DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
-DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(Drawable, MAKE_DISPATCH_PACK(Draw, Area));
+PRO_DEF_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
+PRO_DEF_MEMBER_DISPATCH(Area, Area, double());
+PRO_DEF_FACADE(Drawable, PRO_MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly
 

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -15,8 +15,8 @@ namespace {
 
 namespace poly {
 
-PRO_DEF_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
-PRO_DEF_MEMBER_DISPATCH(Area, Area, double());
+PRO_DEF_MEMBER_DISPATCH(Draw, void(std::ostream&));
+PRO_DEF_MEMBER_DISPATCH(Area, double());
 PRO_DEF_FACADE(Drawable, PRO_MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -17,7 +17,7 @@ namespace poly {
 
 DEFINE_MEMBER_DISPATCH(Draw, Draw, void(std::ostream&));
 DEFINE_MEMBER_DISPATCH(Area, Area, double());
-DEFINE_FACADE(Drawable, Draw, Area);
+DEFINE_FACADE(Drawable, MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly
 

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -16,20 +16,20 @@ namespace {
 namespace poly {
 
 template <class... Os>
-DEFINE_MEMBER_DISPATCH(Call, operator(), Os...);
+PRO_DEF_MEMBER_DISPATCH(Call, operator(), Os...);
 template <class... Os>
-DEFINE_FACADE(Callable, Call<Os...>, pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_pointer_constraints);
 
-DEFINE_FREE_DISPATCH(GetSize, std::ranges::size, std::size_t());
+PRO_DEF_FREE_DISPATCH(GetSize, std::ranges::size, std::size_t());
 
 template <class T>
-DEFINE_FREE_DISPATCH(ForEach, std::ranges::for_each, void(pro::proxy<Callable<void(T&)>>));
+PRO_DEF_FREE_DISPATCH(ForEach, std::ranges::for_each, void(pro::proxy<Callable<void(T&)>>));
 template <class T>
-DEFINE_FACADE(Iterable, MAKE_DISPATCH_PACK(ForEach<T>, GetSize));
+PRO_DEF_FACADE(Iterable, PRO_MAKE_DISPATCH_PACK(ForEach<T>, GetSize));
 
 template <class T> struct Append;
 template <class T>
-DEFINE_FACADE(Container, MAKE_DISPATCH_PACK(ForEach<T>, GetSize, Append<T>));
+PRO_DEF_FACADE(Container, PRO_MAKE_DISPATCH_PACK(ForEach<T>, GetSize, Append<T>));
 template <class T>
 struct Append {
   using overload_types = std::tuple<pro::proxy<Container<T>>(T)>;
@@ -117,7 +117,7 @@ TEST(ProxyInvocationTests, TestMultipleDispatches_Unique) {
 
 TEST(ProxyInvocationTests, TestMultipleDispatches_Duplicated) {
   using SomeCombination = std::tuple<poly::ForEach<int>, std::tuple<poly::GetSize, poly::ForEach<int>>>;
-  DEFINE_FACADE(DuplicatedIterable, MAKE_DISPATCH_PACK(poly::ForEach<int>, SomeCombination, poly::ForEach<int>, poly::GetSize, poly::GetSize));
+  PRO_DEF_FACADE(DuplicatedIterable, PRO_MAKE_DISPATCH_PACK(poly::ForEach<int>, SomeCombination, poly::ForEach<int>, poly::GetSize, poly::GetSize));
   static_assert(sizeof(pro::details::facade_traits<DuplicatedIterable>::meta_type) ==
       sizeof(pro::details::facade_traits<poly::Iterable<int>>::meta_type));
   std::list<int> l = { 1, 2, 3 };

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -16,7 +16,7 @@ namespace {
 namespace poly {
 
 template <class... Os>
-PRO_DEF_MEMBER_DISPATCH(Call, operator(), Os...);
+PRO_DEF_FREE_DISPATCH(Call, std::invoke, Os...);
 template <class... Os>
 PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_pointer_constraints);
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-DEFINE_FACADE(TestFacade, utils::poly::ToString, pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(TestFacade, utils::poly::ToString, pro::copyable_pointer_constraints);
 
 }  // namespace
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -7,9 +7,7 @@
 
 namespace {
 
-struct TestFacade : pro::facade<utils::poly::ToString> {
-  static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
-};
+DEFINE_FACADE(TestFacade, utils::poly::ToString, pro::copyable_pointer_constraints);
 
 }  // namespace
 

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -42,13 +42,13 @@ struct TraitsReflection {
   bool is_trivial_;
 };
 
-DEFINE_FACADE(DefaultFacade);
+PRO_DEF_FACADE(DefaultFacade);
 static_assert(!ReflectionApplicable<DefaultFacade>);
 
-DEFINE_FACADE(TestRttiFacade, MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, RttiReflection);
+PRO_DEF_FACADE(TestRttiFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, RttiReflection);
 static_assert(ReflectionApplicable<TestRttiFacade>);
 
-DEFINE_FACADE(TestTraitsFacade, MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, TraitsReflection);
+PRO_DEF_FACADE(TestTraitsFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, TraitsReflection);
 static_assert(ReflectionApplicable<TestTraitsFacade>);
 
 }  // namespace

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -42,15 +42,13 @@ struct TraitsReflection {
   bool is_trivial_;
 };
 
-using DefaultFacade = pro::facade<>;
+DEFINE_FACADE(DefaultFacade);
 static_assert(!ReflectionApplicable<DefaultFacade>);
 
-struct TestRttiFacade : pro::facade<>
-    { using reflection_type = RttiReflection; };
+DEFINE_FACADE(TestRttiFacade, MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, RttiReflection);
 static_assert(ReflectionApplicable<TestRttiFacade>);
 
-struct TestTraitsFacade : pro::facade<>
-    { using reflection_type = TraitsReflection; };
+DEFINE_FACADE(TestTraitsFacade, MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, TraitsReflection);
 static_assert(ReflectionApplicable<TestTraitsFacade>);
 
 }  // namespace

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -23,7 +23,7 @@ using MockCopyablePtr = MockPtr<true, true, false, sizeof(void*) * 2, alignof(vo
 using MockCopyableSmallPtr = MockPtr<true, true, false, sizeof(void*), alignof(void*)>;
 using MockTrivialPtr = MockPtr<true, true, true, sizeof(void*), alignof(void*)>;
 
-DEFINE_FACADE(DefaultFacade);
+PRO_DEF_FACADE(DefaultFacade);
 static_assert(DefaultFacade::pointer_constraints.minimum_copyability == pro::constraint_level::none);
 static_assert(DefaultFacade::pointer_constraints.minimum_relocatability == pro::constraint_level::nothrow);
 static_assert(DefaultFacade::pointer_constraints.minimum_destructibility == pro::constraint_level::nothrow);
@@ -40,7 +40,7 @@ static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in
 static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in_place_type_t<MockCopyableSmallPtr>, int>);
 static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in_place_type_t<MockTrivialPtr>, int>);
 
-DEFINE_FACADE(RelocatableFacade);
+PRO_DEF_FACADE(RelocatableFacade);
 static_assert(!std::is_copy_constructible_v<pro::proxy<RelocatableFacade>>);
 static_assert(!std::is_copy_assignable_v<pro::proxy<RelocatableFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<RelocatableFacade>>);
@@ -64,7 +64,7 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockCo
 static_assert(std::is_nothrow_constructible_v<pro::proxy<RelocatableFacade>, MockTrivialPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockTrivialPtr>);
 
-DEFINE_FACADE(CopyableFacade, MAKE_DISPATCH_PACK(), pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(CopyableFacade, PRO_MAKE_DISPATCH_PACK(), pro::copyable_pointer_constraints);
 static_assert(std::is_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(!std::is_nothrow_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(std::is_copy_assignable_v<pro::proxy<CopyableFacade>>);
@@ -88,7 +88,7 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockCopya
 static_assert(std::is_nothrow_constructible_v<pro::proxy<CopyableFacade>, MockTrivialPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockTrivialPtr>);
 
-DEFINE_FACADE(CopyableSmallFacade, MAKE_DISPATCH_PACK(), pro::proxy_pointer_constraints{
+PRO_DEF_FACADE(CopyableSmallFacade, PRO_MAKE_DISPATCH_PACK(), pro::proxy_pointer_constraints{
     .maximum_size = sizeof(void*),
     .maximum_alignment = alignof(void*),
     .minimum_copyability = pro::constraint_level::nontrivial,
@@ -108,7 +108,7 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableSmallFacade>, Mock
 static_assert(std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
 static_assert(std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
 
-DEFINE_FACADE(TrivialFacade, MAKE_DISPATCH_PACK(), pro::trivial_pointer_constraints);
+PRO_DEF_FACADE(TrivialFacade, PRO_MAKE_DISPATCH_PACK(), pro::trivial_pointer_constraints);
 static_assert(std::is_trivially_copy_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_copy_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -21,14 +21,14 @@ struct MockPtr {
 using MockMovablePtr = MockPtr<true, false, false, sizeof(void*) * 2, alignof(void*)>;
 using MockCopyablePtr = MockPtr<true, true, false, sizeof(void*) * 2, alignof(void*)>;
 using MockCopyableSmallPtr = MockPtr<true, true, false, sizeof(void*), alignof(void*)>;
-using MockTrivialPtr = MockPtr<true, true, true, sizeof(void*) * 2, alignof(void*)>;
+using MockTrivialPtr = MockPtr<true, true, true, sizeof(void*), alignof(void*)>;
 
-using DefaultFacade = pro::facade<>;
-static_assert(DefaultFacade::minimum_copyability == pro::constraint_level::none);
-static_assert(DefaultFacade::minimum_relocatability == pro::constraint_level::nothrow);
-static_assert(DefaultFacade::minimum_destructibility == pro::constraint_level::nothrow);
-static_assert(DefaultFacade::maximum_size >= 2 * sizeof(void*));
-static_assert(DefaultFacade::maximum_alignment >= sizeof(void*));
+DEFINE_FACADE(DefaultFacade);
+static_assert(DefaultFacade::pointer_constraints.minimum_copyability == pro::constraint_level::none);
+static_assert(DefaultFacade::pointer_constraints.minimum_relocatability == pro::constraint_level::nothrow);
+static_assert(DefaultFacade::pointer_constraints.minimum_destructibility == pro::constraint_level::nothrow);
+static_assert(DefaultFacade::pointer_constraints.maximum_size >= 2 * sizeof(void*));
+static_assert(DefaultFacade::pointer_constraints.maximum_alignment >= sizeof(void*));
 static_assert(std::is_same_v<DefaultFacade::dispatch_types, std::tuple<>>);
 static_assert(std::is_same_v<DefaultFacade::reflection_type, void>);
 static_assert(std::is_nothrow_default_constructible_v<pro::proxy<DefaultFacade>>);
@@ -40,7 +40,7 @@ static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in
 static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in_place_type_t<MockCopyableSmallPtr>, int>);
 static_assert(std::is_nothrow_constructible_v<pro::proxy<DefaultFacade>, std::in_place_type_t<MockTrivialPtr>, int>);
 
-struct RelocatableFacade : pro::facade<> {};
+DEFINE_FACADE(RelocatableFacade);
 static_assert(!std::is_copy_constructible_v<pro::proxy<RelocatableFacade>>);
 static_assert(!std::is_copy_assignable_v<pro::proxy<RelocatableFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<RelocatableFacade>>);
@@ -64,9 +64,7 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockCo
 static_assert(std::is_nothrow_constructible_v<pro::proxy<RelocatableFacade>, MockTrivialPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockTrivialPtr>);
 
-struct CopyableFacade : pro::facade<> {
-  static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
-};
+DEFINE_FACADE(CopyableFacade, MAKE_DISPATCH_PACK(), pro::copyable_pointer_constraints);
 static_assert(std::is_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(!std::is_nothrow_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(std::is_copy_assignable_v<pro::proxy<CopyableFacade>>);
@@ -90,28 +88,27 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockCopya
 static_assert(std::is_nothrow_constructible_v<pro::proxy<CopyableFacade>, MockTrivialPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockTrivialPtr>);
 
-struct CopyableSmallFacade : pro::facade<> {
-  static constexpr std::size_t maximum_size = sizeof(void*);
-  static constexpr auto minimum_copyability = pro::constraint_level::nontrivial;
-};
+DEFINE_FACADE(CopyableSmallFacade, MAKE_DISPATCH_PACK(), pro::proxy_pointer_constraints{
+    .maximum_size = sizeof(void*),
+    .maximum_alignment = alignof(void*),
+    .minimum_copyability = pro::constraint_level::nontrivial,
+    .minimum_relocatability = pro::constraint_level::nothrow,
+    .minimum_destructibility = pro::constraint_level::nothrow,
+  });
 static_assert(!pro::proxiable<MockMovablePtr, CopyableSmallFacade>);
 static_assert(!pro::proxiable<MockCopyablePtr, CopyableSmallFacade>);
 static_assert(pro::proxiable<MockCopyableSmallPtr, CopyableSmallFacade>);
-static_assert(!pro::proxiable<MockTrivialPtr, CopyableSmallFacade>);
+static_assert(pro::proxiable<MockTrivialPtr, CopyableSmallFacade>);
 static_assert(!std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockMovablePtr>);
 static_assert(!std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockMovablePtr>);
 static_assert(!std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockCopyablePtr>);
 static_assert(!std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockCopyablePtr>);
 static_assert(std::is_nothrow_constructible_v<pro::proxy<CopyableSmallFacade>, MockCopyableSmallPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableSmallFacade>, MockCopyableSmallPtr>);
-static_assert(!std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
-static_assert(!std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
+static_assert(std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
+static_assert(std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockTrivialPtr>);
 
-struct TrivialFacade : pro::facade<> {
-  static constexpr auto minimum_copyability = pro::constraint_level::trivial;
-  static constexpr auto minimum_relocatability = pro::constraint_level::trivial;
-  static constexpr auto minimum_destructibility = pro::constraint_level::trivial;
-};
+DEFINE_FACADE(TrivialFacade, MAKE_DISPATCH_PACK(), pro::trivial_pointer_constraints);
 static_assert(std::is_trivially_copy_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_copy_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -83,7 +83,7 @@ class LifetimeTracker {
 namespace poly {
 
 using std::to_string;
-DEFINE_FREE_DISPATCH(ToString, to_string, std::string());
+PRO_DEF_FREE_DISPATCH(ToString, to_string, std::string());
 
 }  // namespace poly
 


### PR DESCRIPTION
**Major changes**

- Added type `proxy_pointer_constraints`, encapsulating `maximum_size`, `maximum_alignment`, `minimum_copyability`, `minimum_relocatability` and `minimum_destructibility` into a single type.
- Added 3 prototypes of `proxy_pointer_constraints` with popular configurations: `relocatable_pointer_constraints`, `copyable_pointer_constraints` and `trivial_pointer_constraints`.
- Added `concept basic_facade` and `concept facade`.
- Removed class templates `dispatch` and `facade`.
- Added macro `PRO_MAKE_DISPATCH_PACK` as an extension.
- Added `PRO_` prefix to the existing macros to avoid collision.
- Revised the semantics of extension `PRO_DEF_FACADE`, making it easier to use.

**Other changes**
- Replaced the SFINAE guarantee of `basic_facade_traits` with `concept facade`.
- Removed `flattening_traits` in the implementation of `dispatch_traits`.
- Updated unit tests accordingly.