### PR TITLE
Improve naming of proxy_pointer_constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ PRO_DEF_FREE_DISPATCH(Call, std::invoke, Overloads...);
 template <class... Overloads>
 PRO_DEF_FACADE(MovableCallable, Call<Overloads...>);
 template <class... Overloads>
-PRO_DEF_FACADE(CopyableCallable, Call<Overloads...>, pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(CopyableCallable, Call<Overloads...>, pro::copyable_ptr_constraints);
 
 }  // namespace poly
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -21,14 +21,14 @@ struct SboObserver {
   bool SboEnabled;
 };
 
-PRO_DEF_FACADE(TestSmallStringable, utils::poly::ToString, pro::proxy_pointer_constraints{
-    .maximum_size = sizeof(void*),
-    .maximum_alignment = alignof(void*),
-    .minimum_copyability = pro::constraint_level::nontrivial,
-    .minimum_relocatability = pro::constraint_level::nothrow,
-    .minimum_destructibility = pro::constraint_level::nothrow,
+PRO_DEF_FACADE(TestSmallStringable, utils::poly::ToString, pro::proxiable_ptr_constraints{
+    .max_size = sizeof(void*),
+    .max_align = alignof(void*),
+    .copyability = pro::constraint_level::nontrivial,
+    .relocatability = pro::constraint_level::nothrow,
+    .destructibility = pro::constraint_level::nothrow,
   }, SboObserver);
-PRO_DEF_FACADE(TestLargeStringable, utils::poly::ToString, pro::copyable_pointer_constraints, SboObserver);
+PRO_DEF_FACADE(TestLargeStringable, utils::poly::ToString, pro::copyable_ptr_constraints, SboObserver);
 
 }  // namespace poly
 

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -18,7 +18,7 @@ namespace poly {
 template <class... Os>
 PRO_DEF_FREE_DISPATCH(Call, std::invoke, Os...);
 template <class... Os>
-PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_ptr_constraints);
 
 PRO_DEF_FREE_DISPATCH(GetSize, std::ranges::size, std::size_t());
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-PRO_DEF_FACADE(TestFacade, utils::poly::ToString, pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(TestFacade, utils::poly::ToString, pro::copyable_ptr_constraints);
 
 }  // namespace
 

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -45,10 +45,10 @@ struct TraitsReflection {
 PRO_DEF_FACADE(DefaultFacade);
 static_assert(!ReflectionApplicable<DefaultFacade>);
 
-PRO_DEF_FACADE(TestRttiFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, RttiReflection);
+PRO_DEF_FACADE(TestRttiFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_ptr_constraints, RttiReflection);
 static_assert(ReflectionApplicable<TestRttiFacade>);
 
-PRO_DEF_FACADE(TestTraitsFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_pointer_constraints, TraitsReflection);
+PRO_DEF_FACADE(TestTraitsFacade, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_ptr_constraints, TraitsReflection);
 static_assert(ReflectionApplicable<TestTraitsFacade>);
 
 }  // namespace

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -25,11 +25,11 @@ using MockTrivialPtr = MockPtr<true, true, true, sizeof(void*), alignof(void*)>;
 using MockFunctionPtr = void(*)();
 
 PRO_DEF_FACADE(DefaultFacade);
-static_assert(DefaultFacade::pointer_constraints.minimum_copyability == pro::constraint_level::none);
-static_assert(DefaultFacade::pointer_constraints.minimum_relocatability == pro::constraint_level::nothrow);
-static_assert(DefaultFacade::pointer_constraints.minimum_destructibility == pro::constraint_level::nothrow);
-static_assert(DefaultFacade::pointer_constraints.maximum_size >= 2 * sizeof(void*));
-static_assert(DefaultFacade::pointer_constraints.maximum_alignment >= sizeof(void*));
+static_assert(DefaultFacade::constraints.copyability == pro::constraint_level::none);
+static_assert(DefaultFacade::constraints.relocatability == pro::constraint_level::nothrow);
+static_assert(DefaultFacade::constraints.destructibility == pro::constraint_level::nothrow);
+static_assert(DefaultFacade::constraints.max_size >= 2 * sizeof(void*));
+static_assert(DefaultFacade::constraints.max_align >= sizeof(void*));
 static_assert(std::is_same_v<DefaultFacade::dispatch_types, std::tuple<>>);
 static_assert(std::is_same_v<DefaultFacade::reflection_type, void>);
 static_assert(std::is_nothrow_default_constructible_v<pro::proxy<DefaultFacade>>);
@@ -69,7 +69,7 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockTr
 static_assert(std::is_nothrow_constructible_v<pro::proxy<RelocatableFacade>, MockFunctionPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<RelocatableFacade>, MockFunctionPtr>);
 
-PRO_DEF_FACADE(CopyableFacade, PRO_MAKE_DISPATCH_PACK(), pro::copyable_pointer_constraints);
+PRO_DEF_FACADE(CopyableFacade, PRO_MAKE_DISPATCH_PACK(), pro::copyable_ptr_constraints);
 static_assert(std::is_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(!std::is_nothrow_copy_constructible_v<pro::proxy<CopyableFacade>>);
 static_assert(std::is_copy_assignable_v<pro::proxy<CopyableFacade>>);
@@ -96,12 +96,12 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockTrivi
 static_assert(std::is_nothrow_constructible_v<pro::proxy<CopyableFacade>, MockFunctionPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockFunctionPtr>);
 
-PRO_DEF_FACADE(CopyableSmallFacade, PRO_MAKE_DISPATCH_PACK(), pro::proxy_pointer_constraints{
-    .maximum_size = sizeof(void*),
-    .maximum_alignment = alignof(void*),
-    .minimum_copyability = pro::constraint_level::nontrivial,
-    .minimum_relocatability = pro::constraint_level::nothrow,
-    .minimum_destructibility = pro::constraint_level::nothrow,
+PRO_DEF_FACADE(CopyableSmallFacade, PRO_MAKE_DISPATCH_PACK(), pro::proxiable_ptr_constraints{
+    .max_size = sizeof(void*),
+    .max_align = alignof(void*),
+    .copyability = pro::constraint_level::nontrivial,
+    .relocatability = pro::constraint_level::nothrow,
+    .destructibility = pro::constraint_level::nothrow,
   });
 static_assert(!pro::proxiable<MockMovablePtr, CopyableSmallFacade>);
 static_assert(!pro::proxiable<MockCopyablePtr, CopyableSmallFacade>);
@@ -119,7 +119,7 @@ static_assert(std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockTrivialP
 static_assert(std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockFunctionPtr>);
 static_assert(std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockFunctionPtr>);
 
-PRO_DEF_FACADE(TrivialFacade, PRO_MAKE_DISPATCH_PACK(), pro::trivial_pointer_constraints);
+PRO_DEF_FACADE(TrivialFacade, PRO_MAKE_DISPATCH_PACK(), pro::trivial_ptr_constraints);
 static_assert(std::is_trivially_copy_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_copy_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);


### PR DESCRIPTION
Work item: #51

Decisions as follows:
1. Renamed `proxy_pointer_constraints` into `proxiable_ptr_constraints`.
2. Shortened every field in `proxiable_ptr_constraints`.
3. In `facade` requirements, changed the required name of `proxiable_ptr_constraints` from `pointer_constraints` into `constraints`.