### PR TITLE
Simplify the semantics of facade per spec

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -498,8 +498,8 @@ class proxy {
   decltype(auto) operator()(Args&&... args) const
       requires(facade<details::dependent_t<F, Args...>> &&
           !std::is_void_v<DefaultDispatch> &&
-          details::dependent_t<details::dispatch_traits<DefaultDispatch>
-              , Args...>::template has_overload<Args...>)
+          details::dependent_t<details::dispatch_traits<DefaultDispatch>,
+              Args...>::template has_overload<Args...>)
       { return invoke(std::forward<Args>(args)...); }
 
  private:
@@ -628,9 +628,8 @@ struct facade_prototype {
     struct NAME : ::pro::details::dispatch_prototype<__VA_ARGS__> { \
       template <class __T, class... __Args> \
       decltype(auto) operator()(__T& __self, __Args&&... __args) \
-          requires( \
-              ::pro::details::matches_overloads<std::tuple<__Args...>, \
-                  std::tuple<__VA_ARGS__>> && \
+          requires(::pro::details::matches_overloads<std::tuple<__Args...>, \
+              std::tuple<__VA_ARGS__>> && \
               requires{ __self.NAME(std::forward<__Args>(__args)...); }) { \
         return __self.NAME(std::forward<__Args>(__args)...); \
       } \
@@ -639,9 +638,8 @@ struct facade_prototype {
     struct NAME : ::pro::details::dispatch_prototype<__VA_ARGS__> { \
       template <class __T, class... __Args> \
       decltype(auto) operator()(__T& __self, __Args&&... __args) \
-          requires( \
-              ::pro::details::matches_overloads<std::tuple<__Args...>, \
-                  std::tuple<__VA_ARGS__>> && \
+          requires(::pro::details::matches_overloads<std::tuple<__Args...>, \
+              std::tuple<__VA_ARGS__>> && \
               requires{ FUNC(__self, std::forward<__Args>(__args)...); }) { \
         return FUNC(__self, std::forward<__Args>(__args)...); \
       } \

--- a/proxy.h
+++ b/proxy.h
@@ -439,8 +439,8 @@ class proxy {
   ~proxy() requires(HasTrivialDestructor) = default;
   ~proxy() requires(!HasDestructor) = delete;
 
-  [[nodiscard]] bool has_value() const noexcept { return meta_ != nullptr; }
-  [[nodiscard]] decltype(auto) reflect() const noexcept
+  bool has_value() const noexcept { return meta_ != nullptr; }
+  decltype(auto) reflect() const noexcept
       requires(!std::is_void_v<typename F::reflection_type>)
       { return static_cast<const typename F::reflection_type&>(*meta_); }
   void reset() noexcept(HasNothrowDestructor) requires(HasDestructor)

--- a/proxy.h
+++ b/proxy.h
@@ -580,10 +580,9 @@ struct overload_args_traits<R(Args...)> { using type = std::tuple<Args&&...>; };
 template <class Args, class Os>
 struct overloads_matching_traits : inapplicable_traits {};
 template <class... Args, class... Os>
-    requires(contains_traits<std::tuple<Args&&...>,
-        typename overload_args_traits<Os>::type...>::applicable)
 struct overloads_matching_traits<std::tuple<Args...>, std::tuple<Os...>>
-    : applicable_traits {};
+    : contains_traits<std::tuple<Args&&...>,
+          typename overload_args_traits<Os>::type...> {};
 template <class Args, class Os>
 concept matches_overloads = overloads_matching_traits<Args, Os>::applicable;
 
@@ -607,14 +606,12 @@ struct flattening_traits<std::tuple<T, Ts...>> : flattening_traits_impl<
 
 template <class... Os> requires(sizeof...(Os) > 0u)
 struct dispatch_prototype { using overload_types = std::tuple<Os...>; };
-
 template <class... Ds> requires(sizeof...(Ds) > 0u)
-struct combined_dispatch : Ds... {
+struct combined_dispatch_prototype : Ds... {
   using overload_types = typename flattening_traits<
       std::tuple<typename Ds::overload_types...>>::type;
   using Ds::operator()...;
 };
-
 template <class Ds = std::tuple<>, proxiable_ptr_constraints C =
     relocatable_ptr_constraints, class R = void>
 struct facade_prototype {
@@ -650,7 +647,7 @@ struct facade_prototype {
       } \
     }
 #define PRO_DEF_COMBINED_DISPATCH(NAME, ...) \
-    struct NAME : ::pro::details::combined_dispatch<__VA_ARGS__> {}
+    struct NAME : ::pro::details::combined_dispatch_prototype<__VA_ARGS__> {}
 #define PRO_MAKE_DISPATCH_PACK(...) std::tuple<__VA_ARGS__>
 #define PRO_DEF_FACADE(NAME, ...) \
     struct NAME : ::pro::details::facade_prototype<__VA_ARGS__> {}

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -155,14 +155,28 @@ static_assert(pro::proxiable<MockTrivialPtr, RelocatableFacadeWithReflection>);
 static_assert(pro::proxiable<MockFunctionPtr, RelocatableFacadeWithReflection>);
 
 struct BadFacade_MissingDispatchTypes {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
+#endif  // __clang__
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
   using reflection_type = void;
 };
 static_assert(!pro::basic_facade<BadFacade_MissingDispatchTypes>);
 
 struct BadFacade_BadDispatchTypes {
   using dispatch_types = int;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
+#endif  // __clang__
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
   using reflection_type = void;
 };
 static_assert(!pro::basic_facade<BadFacade_BadDispatchTypes>);

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -143,4 +143,80 @@ static_assert(std::is_nothrow_assignable_v<pro::proxy<TrivialFacade>, MockTrivia
 static_assert(std::is_nothrow_constructible_v<pro::proxy<TrivialFacade>, MockFunctionPtr>);
 static_assert(std::is_nothrow_assignable_v<pro::proxy<TrivialFacade>, MockFunctionPtr>);
 
+struct ReflectionOfSmallPtr {
+  template <class P> requires(sizeof(P) <= sizeof(void*))
+  constexpr ReflectionOfSmallPtr(std::in_place_type_t<P>) {}
+};
+PRO_DEF_FACADE(RelocatableFacadeWithReflection, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_ptr_constraints, ReflectionOfSmallPtr);
+static_assert(!pro::proxiable<MockMovablePtr, RelocatableFacadeWithReflection>);
+static_assert(!pro::proxiable<MockCopyablePtr, RelocatableFacadeWithReflection>);
+static_assert(pro::proxiable<MockCopyableSmallPtr, RelocatableFacadeWithReflection>);
+static_assert(pro::proxiable<MockTrivialPtr, RelocatableFacadeWithReflection>);
+static_assert(pro::proxiable<MockFunctionPtr, RelocatableFacadeWithReflection>);
+
+struct BadFacade_MissingDispatchTypes {
+  static constexpr auto constraints = pro::relocatable_ptr_constraints;
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_MissingDispatchTypes>);
+
+struct BadFacade_BadDispatchTypes {
+  using dispatch_types = int;
+  static constexpr auto constraints = pro::relocatable_ptr_constraints;
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_BadDispatchTypes>);
+
+struct BadFacade_MissingConstraints {
+  using dispatch_types = std::tuple<>;
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_MissingConstraints>);
+
+struct BadFacade_BadConstraints_UnexpectedType {
+  using dispatch_types = std::tuple<>;
+  static constexpr auto constraints = 0;
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_BadConstraints_UnexpectedType>);
+
+struct BadFacade_BadConstraints_BadAlignment {
+  using dispatch_types = std::tuple<>;
+  static constexpr pro::proxiable_ptr_constraints constraints{
+      .max_size = 6u,
+      .max_align = 6u, // Should be a power of 2
+      .copyability = pro::constraint_level::none,
+      .relocatability = pro::constraint_level::nothrow,
+      .destructibility = pro::constraint_level::nothrow,
+  };
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_BadConstraints_BadAlignment>);
+
+struct BadFacade_BadConstraints_BadSize {
+  using dispatch_types = std::tuple<>;
+  static constexpr pro::proxiable_ptr_constraints constraints{
+      .max_size = 6u, // Should be a multiple of max_alignment
+      .max_align = 4u,
+      .copyability = pro::constraint_level::none,
+      .relocatability = pro::constraint_level::nothrow,
+      .destructibility = pro::constraint_level::nothrow,
+  };
+  using reflection_type = void;
+};
+static_assert(!pro::basic_facade<BadFacade_BadConstraints_BadSize>);
+
+struct BadFacade_MissingReflectionType {
+  using dispatch_types = std::tuple<>;
+  static constexpr auto constraints = pro::relocatable_ptr_constraints;
+};
+static_assert(!pro::basic_facade<BadFacade_MissingReflectionType>);
+
+struct BadFacade_BadReflectionType {
+  using dispatch_types = std::tuple<>;
+  static constexpr auto constraints = pro::relocatable_ptr_constraints;
+  using reflection_type = std::unique_ptr<int>;
+};
+static_assert(!pro::basic_facade<BadFacade_BadReflectionType>);
+
 }  // namespace


### PR DESCRIPTION
To simplify the semantics of `proxy`, several changes has been made as per the latest spec:
1. Defining repeated dispatches in a `facade` is no longer supported. An author of a `facade` should guarantee every `dispatch` is unique. Helper macros will serve this purpose with metaprogramming at compile time.
2. `concept basic_facade` was strengthened with the following additions: a) `F::dispatch_types` shall be a specialization of `std::tuple`; b) The type of `F::constraints` shall be exactly `const pro::proxiable_ptr_constraints`, no implicit conversion is allowed; c) the maximum size and alignment defined by `F::constraints` shall follow the rule of C++; d) When `F::reflection_type` is not `void`, it shall be trivially copyable.
3. `concept facade` was strengthen with the following addition: Each dispatch type defined by `F::dispatch_types` shall be trivially default constructible.

Some test cases are added to verify the constraints work as expected. No functional changes.