### PR TITLE
Fix self-move-assignment for `proxy`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -419,12 +419,14 @@ class proxy {
   proxy& operator=(const proxy&) requires(!HasCopyAssignment) = delete;
   proxy& operator=(proxy&& rhs) noexcept(HasNothrowMoveAssignment)
     requires(HasMoveAssignment) {
-    if constexpr (HasNothrowMoveAssignment) {
-      this->~proxy();
-    } else {
-      reset();  // For weak exception safety
+    if (this != &rhs) {
+      if constexpr (HasNothrowMoveAssignment) {
+        this->~proxy();
+      } else {
+        reset();  // For weak exception safety
+      }
+      new(this) proxy(std::move(rhs));
     }
-    new(this) proxy(std::move(rhs));
     return *this;
   }
   proxy& operator=(proxy&&) requires(!HasMoveAssignment) = delete;

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -649,12 +649,10 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToSelf) {
 #elif defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif  // __clang__
-    ASSERT_FALSE(p.has_value());
-    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
-    expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
-    expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+    ASSERT_TRUE(p.has_value());
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
+  expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 


### PR DESCRIPTION
Fixes #36.

See also [LWG2839](https://cplusplus.github.io/LWG/issue2839).