### PR TITLE
Add support for `noexcept`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -518,8 +518,8 @@ class proxy {
           requires { typename details::dispatch_traits<D>
               ::template matched_overload<Args...>; }) {
     using DispatcherType = typename details::overload_traits<
-        details::dispatch_traits<D>::template matched_overload<Args...>>
-        ::dispatcher_type;
+        typename details::dispatch_traits<D>
+            ::template matched_overload<Args...>>::dispatcher_type;
     const auto& dispatchers = static_cast<const typename Traits::meta_type*>(
         meta_)->template dispatch_meta<D>::dispatchers;
     const auto& dispatcher = std::get<DispatcherType>(dispatchers);

--- a/proxy.h
+++ b/proxy.h
@@ -519,11 +519,10 @@ class proxy {
       requires(facade<details::dependent_t<F, Args...>> &&
           BasicTraits::template has_dispatch<D> &&
           requires { typename MatchedOverload<D, Args...>; }) {
-    using DispatcherType = typename details::overload_traits<
-        MatchedOverload<D, Args...>>::dispatcher_type;
     const auto& dispatchers = static_cast<const typename Traits::meta_type*>(
         meta_)->template dispatch_meta<D>::dispatchers;
-    auto dispatcher = std::get<DispatcherType>(dispatchers);
+    auto dispatcher = std::get<typename details::overload_traits<
+        MatchedOverload<D, Args...>>::dispatcher_type>(dispatchers);
     return dispatcher(ptr_, std::forward<Args>(args)...);
   }
 

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -16,7 +16,7 @@ namespace {
 namespace poly {
 
 PRO_DEF_MEMBER_DISPATCH(Draw, void(std::ostream&));
-PRO_DEF_MEMBER_DISPATCH(Area, double());
+PRO_DEF_MEMBER_DISPATCH(Area, double() noexcept);
 PRO_DEF_FACADE(Drawable, PRO_MAKE_DISPATCH_PACK(Draw, Area));
 
 }  // namespace poly
@@ -27,7 +27,7 @@ class Rectangle {
       { out << "{Rectangle: width = " << width_ << ", height = " << height_ << "}"; }
   void SetWidth(double width) { width_ = width; }
   void SetHeight(double height) { height_ = height; }
-  double Area() const { return width_ * height_; }
+  double Area() const noexcept { return width_ * height_; }
 
  private:
   double width_;
@@ -38,7 +38,7 @@ class Circle {
  public:
   void Draw(std::ostream& out) const { out << "{Circle: radius = " << radius_ << "}"; }
   void SetRadius(double radius) { radius_ = radius; }
-  double Area() const { return std::numbers::pi * radius_ * radius_; }
+  double Area() const noexcept { return std::numbers::pi * radius_ * radius_; }
 
  private:
   double radius_;
@@ -47,7 +47,7 @@ class Circle {
 class Point {
  public:
   void Draw(std::ostream& out) const { out << "{Point}"; }
-  constexpr double Area() const { return 0; }
+  constexpr double Area() const noexcept { return 0; }
 };
 
 std::string PrintDrawableToString(pro::proxy<poly::Drawable> p) {

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -15,10 +15,10 @@ namespace {
 
 namespace poly {
 
-template <class... O>
-PRO_DEF_FREE_DISPATCH(Call, std::invoke, O...);
-template <class... O>
-PRO_DEF_FACADE(Callable, Call<O...>, pro::copyable_ptr_constraints);
+template <class... Os>
+PRO_DEF_FREE_DISPATCH(Call, std::invoke, Os...);
+template <class... Os>
+PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_ptr_constraints);
 
 PRO_DEF_FREE_DISPATCH(GetSize, std::ranges::size, std::size_t() noexcept);
 


### PR DESCRIPTION
**Changes**

- Extended the requirements of dispatch types in `concept facade` to support `noexcept` overloads.
- Added `noexcept` constraints to pointer address deduction (see `details::ptr_traits`), with regard to the semantics of `std::to_address()`.
- Updated the implementation of `proxy` and helper macros accordingly.
- Added several unit test cases to cover this change.

Note that partial template specialization `details::overload_traits<R(Args...)>` and `overload_traits<R(Args...) noexcept>` cannot be merged due to [a bug in the implementation of Clang](https://github.com/llvm/llvm-project/issues/81962).

**The documentation will be updated later.**