### PR TITLE
Add `noexcept` for copyability, relocatability and destructibility metadata

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -125,7 +125,6 @@ struct overload_traits<R(Args...)> : applicable_traits {
   static constexpr bool applicable_ptr = std::is_invocable_v<
       D, typename ptr_traits<P>::reference_type, Args...>;
   static constexpr bool is_noexcept = false;
-
   template <class D, class P>
   static R dispatcher(const char* erased, Args... args) {
     auto ptr = ptr_traits<P>::to_address(*reinterpret_cast<const P*>(erased));
@@ -146,7 +145,6 @@ struct overload_traits<R(Args...) noexcept> : applicable_traits {
   static constexpr bool applicable_ptr = std::is_nothrow_invocable_v<
       D, typename ptr_traits<P>::reference_type, Args...>;
   static constexpr bool is_noexcept = true;
-
   template <class D, class P>
   static R dispatcher(const char* erased, Args... args) noexcept {
     auto ptr = ptr_traits<P>::to_address(*reinterpret_cast<const P*>(erased));

--- a/proxy.h
+++ b/proxy.h
@@ -537,7 +537,7 @@ class proxy {
     using dispatcher_type = typename details::overload_traits<
         MatchedOverload<D, Args...>>::dispatcher_type;
     const auto& dispatchers = static_cast<const typename Traits::meta*>(meta_)
-        ->details::dispatch_traits<D>::meta::dispatchers;
+        ->details::template dispatch_traits<D>::meta::dispatchers;
     auto dispatcher = std::get<dispatcher_type>(dispatchers);
     return dispatcher(ptr_, std::forward<Args>(args)...);
   }

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -126,8 +126,8 @@ TEST(ProxyInvocationTests, TestMultipleDispatches_Unique) {
 TEST(ProxyInvocationTests, TestMultipleDispatches_Duplicated) {
   using SomeCombination = std::tuple<poly::ForEach<int>, std::tuple<poly::GetSize, poly::ForEach<int>>>;
   PRO_DEF_FACADE(DuplicatedIterable, PRO_MAKE_DISPATCH_PACK(poly::ForEach<int>, SomeCombination, poly::ForEach<int>, poly::GetSize, poly::GetSize));
-  static_assert(sizeof(pro::details::facade_traits<DuplicatedIterable>::meta_type) ==
-      sizeof(pro::details::facade_traits<poly::Iterable<int>>::meta_type));
+  static_assert(sizeof(pro::details::facade_traits<DuplicatedIterable>::meta) ==
+      sizeof(pro::details::facade_traits<poly::Iterable<int>>::meta));
   std::list<int> l = { 1, 2, 3 };
   pro::proxy<DuplicatedIterable> p = &l;
   ASSERT_EQ(p.invoke<poly::GetSize>(), 3);


### PR DESCRIPTION
When the copyability, relocatability or destructibility of a `facade` is `nothrow`, their underlying function pointers are not. This change makes the underlying function pointers `noexcept` when possible.

This change improves the quality of implementation with necessary refactoring. No functional changes.