### PR TITLE
Improve compile-time constraints for constants

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -335,8 +335,6 @@ template <class F>
           typename F::reflection_type;
         } &&
         is_constexpr<facade_constraints_visitor<F>> &&
-        std::is_same_v<decltype(F::constraints),
-            const proxiable_ptr_constraints> &&
         std::has_single_bit(F::constraints.max_align) &&
         F::constraints.max_size % F::constraints.max_align == 0u &&
         (std::is_void_v<typename F::reflection_type> ||

--- a/proxy.h
+++ b/proxy.h
@@ -49,7 +49,7 @@ template <template <class> class T, class... Is>
 using first_applicable_t = typename first_applicable<T, Is...>::type;
 
 template <class Expr>
-consteval bool is_constexpr(Expr)
+consteval bool is_consteval(Expr)
     { return requires { typename std::bool_constant<(Expr{}(), false)>; }; }
 
 template <class T>
@@ -282,7 +282,7 @@ struct facade_meta_reduction<composite_meta<Ms...>, I>
 
 template <class F>
 consteval bool is_facade_constraints_well_formed() {
-  if constexpr (is_constexpr([] { return F::constraints; })) {
+  if constexpr (is_consteval([] { return F::constraints; })) {
     return std::has_single_bit(F::constraints.max_align) &&
       F::constraints.max_size % F::constraints.max_align == 0u;
   }
@@ -294,7 +294,7 @@ consteval bool is_facade_reflection_type_well_formed() {
   if constexpr (std::is_void_v<R>) {
     return true;
   } else if constexpr (std::is_constructible_v<R, std::in_place_type_t<P>>) {
-    return is_constexpr([] { return R{std::in_place_type<P>}; });
+    return is_consteval([] { return R{std::in_place_type<P>}; });
   }
   return false;
 }

--- a/proxy.h
+++ b/proxy.h
@@ -284,7 +284,7 @@ template <class F>
 consteval bool is_facade_constraints_well_formed() {
   if constexpr (is_consteval([] { return F::constraints; })) {
     return std::has_single_bit(F::constraints.max_align) &&
-      F::constraints.max_size % F::constraints.max_align == 0u;
+        F::constraints.max_size % F::constraints.max_align == 0u;
   }
   return false;
 }

--- a/proxy.h
+++ b/proxy.h
@@ -283,12 +283,9 @@ consteval bool is_constexpr(Expr)
 
 template <class F>
 consteval bool is_facade_constraints_well_formed() {
-  if constexpr (requires { { F::constraints } ->
-      std::same_as<const proxiable_ptr_constraints&>; }) {
-    if constexpr (is_constexpr([] { return F::constraints; })) {
-      return std::has_single_bit(F::constraints.max_align) &&
-        F::constraints.max_size % F::constraints.max_align == 0u;
-    }
+  if constexpr (is_constexpr([] { return F::constraints; })) {
+    return std::has_single_bit(F::constraints.max_align) &&
+      F::constraints.max_size % F::constraints.max_align == 0u;
   }
   return false;
 }
@@ -308,9 +305,8 @@ struct facade_traits_impl<F, std::tuple<Ds...>>
       return true;
     } else if constexpr (std::is_constructible_v<R, std::in_place_type_t<P>>) {
       return is_constexpr([] { return R{std::in_place_type<P>}; });
-    } else {
-      return false;
     }
+    return false;
   }
 
   using copyability_meta = lifetime_meta<
@@ -341,6 +337,7 @@ template <class F>
     requires(
         requires {
           typename F::dispatch_types;
+          { F::constraints } -> std::same_as<const proxiable_ptr_constraints&>;
           typename F::reflection_type;
         } &&
         is_facade_constraints_well_formed<F>() &&

--- a/proxy.h
+++ b/proxy.h
@@ -48,10 +48,9 @@ struct first_applicable<T, I, Is...> : first_applicable<T, Is...> {};
 template <template <class> class T, class... Is>
 using first_applicable_t = typename first_applicable<T, Is...>::type;
 
-template <int> struct is_constexpr_helper;
 template <class Expr>
 consteval bool is_constexpr(Expr)
-    { return requires { typename is_constexpr_helper<(Expr{}(), 0)>; }; }
+    { return requires { typename std::bool_constant<(Expr{}(), false)>; }; }
 
 template <class T>
 consteval bool has_copyability(constraint_level level) {
@@ -338,10 +337,7 @@ template <class F>
           typename F::dispatch_types;
           { F::constraints } -> std::same_as<const proxiable_ptr_constraints&>;
           typename F::reflection_type;
-        } &&
-        is_facade_constraints_well_formed<F>() &&
-        (std::is_void_v<typename F::reflection_type> ||
-            std::is_trivially_copyable_v<typename F::reflection_type>))
+        } && is_facade_constraints_well_formed<F>())
 struct facade_traits<F> : facade_traits_impl<F, typename F::dispatch_types> {};
 
 using ptr_prototype = void*[2];

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -12,10 +12,10 @@ namespace poly {
 struct SboObserver {
  public:
   template <class P>
-  constexpr explicit SboObserver(std::in_place_type_t<pro::details::sbo_ptr<P>>) noexcept
+  constexpr explicit SboObserver(std::in_place_type_t<pro::details::sbo_ptr<P>>)
       : SboEnabled(true) {}
   template <class P>
-  constexpr explicit SboObserver(std::in_place_type_t<P>) noexcept
+  constexpr explicit SboObserver(std::in_place_type_t<P>)
       : SboEnabled(false) {}
 
   bool SboEnabled;

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -16,7 +16,7 @@ concept ReflectionApplicable = requires(pro::proxy<F> p) {
 class RttiReflection {
  public:
   template <class P>
-  constexpr explicit RttiReflection(std::in_place_type_t<P>) noexcept
+  constexpr explicit RttiReflection(std::in_place_type_t<P>)
       : type_(typeid(P)) {}
 
   const char* GetName() const noexcept { return type_.name(); }
@@ -28,7 +28,7 @@ class RttiReflection {
 struct TraitsReflection {
  public:
   template <class P>
-  constexpr explicit TraitsReflection(std::in_place_type_t<P>) noexcept
+  constexpr explicit TraitsReflection(std::in_place_type_t<P>)
       : is_default_constructible_(std::is_default_constructible_v<P>),
         is_copy_constructible_(std::is_copy_constructible_v<P>),
         is_nothrow_move_constructible_(std::is_nothrow_move_constructible_v<P>),

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -242,7 +242,14 @@ static_assert(!pro::facade<BadFacade_BadConstraints_NotConstant>);
 
 struct BadFacade_MissingReflectionType {
   using dispatch_types = std::tuple<>;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
+#endif  // __clang__
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 };
 static_assert(!pro::facade<BadFacade_MissingReflectionType>);
 

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -249,8 +249,8 @@ static_assert(!pro::facade<BadFacade_MissingReflectionType>);
 struct BadFacade_BadReflectionType {
   using dispatch_types = std::tuple<>;
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
-  using reflection_type = std::unique_ptr<int>;
+  using reflection_type = std::unique_ptr<int>;  // Probably constexpr, unknown until the evaluation of proxiablility
 };
-static_assert(!pro::facade<BadFacade_BadReflectionType>);
+static_assert(pro::facade<BadFacade_BadReflectionType>);
 
 }  // namespace

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -242,14 +242,7 @@ static_assert(!pro::facade<BadFacade_BadConstraints_NotConstant>);
 
 struct BadFacade_MissingReflectionType {
   using dispatch_types = std::tuple<>;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-const-variable"
-#endif  // __clang__
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif  // __clang__
 };
 static_assert(!pro::facade<BadFacade_MissingReflectionType>);
 


### PR DESCRIPTION
Since there is no facility in the standard to tell if an expression is evaluated at compile-time (like `noexcept(expr)`), we used to use `std::is_nothrow_constructible` in the implementation of `proxy`. It is not equivalent to that a value could be constructed at compile-time. We did a little trick `is_consteval` in this change to improve the constraints. Some `noexcept` in the reflection types in unit tests are removed (reverted from the last PR). 2 test cases are added.