### PR TITLE
Resolve review comments of P3086R1 from the ISO C++ committee

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -224,8 +224,7 @@ struct composite_meta : Ms... {
 
 template <class D>
 struct dispatch_helper {
-  template <class... Os>
-  struct traits : inapplicable_traits {};
+  template <class... Os> struct traits : inapplicable_traits {};
   template <class... Os>
       requires(sizeof...(Os) > 0u && (overload_traits<Os>::applicable && ...))
   struct traits<Os...> : applicable_traits {
@@ -328,8 +327,7 @@ template <class D>
 struct default_dispatch_traits<D> { using default_dispatch = D; };
 template <class F>
 struct facade_helper {
-  template <class... Ds>
-  struct traits : inapplicable_traits {};
+  template <class... Ds> struct traits : inapplicable_traits {};
   template <class... Ds> requires(dispatch_traits<Ds>::applicable && ...)
   struct traits<Ds...> : applicable_traits, default_dispatch_traits<Ds...> {
     using copyability_meta = lifetime_meta<
@@ -382,8 +380,7 @@ struct meta_ptr {
 
  private:
   const M* ptr_;
-  template <class P>
-  static constexpr M storage{std::in_place_type<P>};
+  template <class P> static constexpr M storage{std::in_place_type<P>};
 };
 template <class M>
     requires(sizeof(M) <= sizeof(ptr_prototype) &&

--- a/proxy.h
+++ b/proxy.h
@@ -64,7 +64,7 @@ concept tuple_like =
 template <template <class...> class T, class TL, class Is> struct instantiated;
 template <template <class...> class T, class TL, std::size_t... Is>
 struct instantiated<T, TL, std::index_sequence<Is...>>
-    : std::type_identity<T<std::tuple_element_t<Is, TL>...>> {};
+    { using type = T<std::tuple_element_t<Is, TL>...>; };
 template <template <class...> class T, class TL>
 using instantiated_t = typename instantiated<
     T, TL, std::make_index_sequence<std::tuple_size_v<TL>>>::type;

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -252,7 +252,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_WithoutSBO_IndirectAllocator_FromValu
   expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
   {
     std::pmr::unsynchronized_pool_resource memory_pool;
-    auto p = pro::allocate_proxy<poly::TestSmallStringable>(std::pmr::polymorphic_allocator{&memory_pool}, session);
+    auto p = pro::allocate_proxy<poly::TestSmallStringable>(std::pmr::polymorphic_allocator<>{&memory_pool}, session);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(p.invoke(), "Session 2");
     ASSERT_FALSE(p.reflect().SboEnabled);
@@ -269,7 +269,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_WithoutSBO_IndirectAllocator_InPlace)
   std::vector<utils::LifetimeOperation> expected_ops;
   {
     std::pmr::unsynchronized_pool_resource memory_pool;
-    auto p = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator{&memory_pool}, & tracker);
+    auto p = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, & tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(p.invoke(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
@@ -286,7 +286,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_WithoutSBO_IndirectAllocator_InPlaceI
   std::vector<utils::LifetimeOperation> expected_ops;
   {
     std::pmr::unsynchronized_pool_resource memory_pool;
-    auto p = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator{&memory_pool}, { 1, 2, 3 }, & tracker);
+    auto p = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, { 1, 2, 3 }, & tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(p.invoke(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
@@ -303,7 +303,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_WithoutSBO_IndirectAllocator_Lifetime
   std::vector<utils::LifetimeOperation> expected_ops;
   {
     std::pmr::unsynchronized_pool_resource memory_pool;
-    auto p1 = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator{&memory_pool}, & tracker);
+    auto p1 = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, & tracker);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
@@ -327,7 +327,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_WithoutSBO_IndirectAllocator_Lifetime
   std::vector<utils::LifetimeOperation> expected_ops;
   {
     std::pmr::unsynchronized_pool_resource memory_pool;
-    auto p1 = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator{&memory_pool}, & tracker);
+    auto p1 = pro::allocate_proxy<poly::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, & tracker);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
 #include <stdexcept>
 #include <type_traits>
 #include "proxy.h"

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include "proxy.h"
+#include "utils.h"
 
 namespace {
 
@@ -166,6 +167,13 @@ struct RuntimeReflection {
 };
 PRO_DEF_FACADE(FacadeWithRuntimeReflection, PRO_MAKE_DISPATCH_PACK(), pro::relocatable_ptr_constraints, RuntimeReflection);
 static_assert(!pro::proxiable<MockTrivialPtr, FacadeWithRuntimeReflection>);
+
+struct FacadeWithTupleLikeDispatches {
+  using dispatch_types = std::array<utils::poly::ToString, 1>;
+  static constexpr auto constraints = pro::relocatable_ptr_constraints;
+  using reflection_type = void;
+};
+static_assert(pro::facade<FacadeWithTupleLikeDispatches>);
 
 struct BadFacade_MissingDispatchTypes {
 #ifdef __clang__


### PR DESCRIPTION
As per review comments of [P3086R1](https://isocpp.org/files/papers/P3086R1.pdf), two design issues were raised. More details of the review are documented [here](https://github.com/cplusplus/papers/issues/1741). The two issues are:

1. the semantics of `concept facade` should expect `tuple-like` types rather than specializations of `std::tuple` to stay consistency with the existing standard.
2. `make_proxy` lacks allocator support. Since `proxy` does not rely on this facility, splitting into a separate paper is recommended.

For 1, the implementation of was updated in this change to accept any `tuple-like` types in `concept facade`, `PRO_DEF_FACADE` and `proxy`. Another case was added in tests/proxy_traits_tests.cpp.

For 2, a new API `allocate_proxy` was added in this change. 15 new cases were added in tests/proxy_creation_tests.cpp.

Closes #74 
Closes #75 