### PR TITLE
Support default implementation of a dispatch

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -147,10 +147,6 @@ consteval bool is_invoker_well_formed() {
   }
   return false;
 }
-template <class F, bool NE, class R, class... Args>
-constexpr bool invocable_dispatch_impl =
-    std::conditional<NE, std::is_nothrow_invocable_r<R, F, Args...>,
-        std::is_invocable_r<R, F, Args...>>::value;
 template <class D, class T, bool NE, class R, class... Args>
 concept invocable_dispatch = requires { typename D::template invoker<T>; } &&
     is_invoker_well_formed<

--- a/proxy.h
+++ b/proxy.h
@@ -180,9 +180,6 @@ static R dispatcher_impl(const char* erased, Args... args) noexcept(NE) {
 }
 template <bool NE, class R, class... Args>
 struct overload_traits_impl : applicable_traits {
- private:
-
- public:
   template <class D>
   struct meta_provider {
     template <class P>

--- a/proxy.h
+++ b/proxy.h
@@ -846,11 +846,11 @@ struct facade_prototype {
     }
 #define PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
-        __self.__FUNC(std::forward<__Args>(__args)...),\
+        __self.__FUNC(std::forward<__Args>(__args)...), \
         __DEFFUNC(std::forward<__Args>(__args)...), std::tuple<__VA_ARGS__>)
 #define PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
-        __FUNC(__self, std::forward<__Args>(__args)...),\
+        __FUNC(__self, std::forward<__Args>(__args)...), \
         __DEFFUNC(std::forward<__Args>(__args)...), std::tuple<__VA_ARGS__>)
 #define PRO_DEF_MEMBER_DISPATCH(__NAME, ...) \
     PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT( \

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -20,6 +20,12 @@ PRO_DEF_FREE_DISPATCH(Call, std::invoke, Os...);
 template <class... Os>
 PRO_DEF_FACADE(Callable, Call<Os...>, pro::copyable_ptr_constraints);
 
+void NotImplemented(auto&&...) { throw std::runtime_error{ "Not implemented!" }; }
+template <class... Os>
+PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(WeakCall, std::invoke, NotImplemented, Os...);
+template <class... Os>
+PRO_DEF_FACADE(WeakCallable, WeakCall<Os...>, pro::copyable_ptr_constraints);
+
 PRO_DEF_FREE_DISPATCH(GetSize, std::ranges::size, std::size_t() noexcept);
 
 template <class T>
@@ -30,16 +36,14 @@ PRO_DEF_FACADE(Iterable, PRO_MAKE_DISPATCH_PACK(ForEach<T>, GetSize));
 template <class T> struct Append;
 template <class T>
 PRO_DEF_FACADE(Container, PRO_MAKE_DISPATCH_PACK(ForEach<T>, GetSize, Append<T>));
-template <class T>
-struct Append {
-  using overload_types = std::tuple<pro::proxy<Container<T>>(T)>;
 
-  template <class U>
-  pro::proxy<Container<T>> operator()(U& self, T&& value) {
-    self.push_back(std::move(value));
-    return &self;
-  }
-};
+template <class C, class T>
+pro::proxy<Container<T>> AppendImpl(C& container, T&& v) {
+  container.push_back(std::move(v));
+  return &container;
+}
+template <class T>
+PRO_DEF_FREE_DISPATCH(Append, AppendImpl, pro::proxy<Container<T>>(T));
 
 }  // namespace spec
 
@@ -153,8 +157,7 @@ TEST(ProxyInvocationTests, TestRecursiveDefinition) {
 }
 
 TEST(ProxyInvocationTests, TestOverloadResolution) {
-  PRO_DEF_COMBINED_DISPATCH(OverloadedCall, spec::Call<void(int)>, spec::Call<void(double)>, spec::Call<void(char*)>, spec::Call<void(const char*)>, spec::Call<void(std::string, int)>);
-  PRO_DEF_FACADE(OverloadedCallable, OverloadedCall);
+  PRO_DEF_FACADE(OverloadedCallable, spec::Call<void(int), void(double), void(const char*), void(char*), void(std::string, int)>);
   std::vector<std::type_index> side_effect;
   auto p = pro::make_proxy<OverloadedCallable>([&](auto&&... args)
       { side_effect = GetTypeIndices<std::decay_t<decltype(args)>...>(); });
@@ -193,18 +196,15 @@ TEST(ProxyInvocationTests, TestFunctionPointer) {
 }
 
 TEST(ProxyInvocationTests, TestCombinationWithIncompleteDispatch) {
-  constexpr auto not_implemented = [](auto&&...) { throw std::runtime_error{ "Not implemented!" }; };
-  PRO_DEF_COMBINED_DISPATCH(WeakCall, spec::Call<void()>, decltype(not_implemented));
-  PRO_DEF_FACADE(WeakCallable, WeakCall);
   {
     int side_effect = 0;
-    auto p = pro::make_proxy<WeakCallable>([&] { side_effect = 1; });
+    auto p = pro::make_proxy<spec::WeakCallable<void()>>([&] { side_effect = 1; });
     p();
     ASSERT_EQ(side_effect, 1);
   }
   {
     bool exception_thrown = false;
-    auto p = pro::make_proxy<WeakCallable>(123);
+    auto p = pro::make_proxy<spec::WeakCallable<void()>>(123);
     try {
       p();
     } catch (const std::runtime_error& e) {


### PR DESCRIPTION
**Changes**

- Added macro `PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT` and `PRO_DEF_FREE_DISPATCH_WITH_DEFAULT` to allow specifying an addition default implementation of a dispatch.
- Added support for compilers to avoid generating duplicated code for the default implementation of a dispatch.
- Removed macro `PRO_DEF_COMBINED_DISPATCH` due to incompatibility of semantics.
- Revised semantics of `concept facade` and `proxiable`: Before this change, implementation of a dispatch is required to provide overloads of `operator()`, and a facade is required to be trivially default constructible. It is now required that a dispatch `D` shall be trivially default constructible, and shall model `typename D::template invoker<...>`. `proxy` will try to instantiate `invoker` with `target-type-of<P>` (implemented as `pro::details::ptr_traits<P>::target_type`) and see if it is invocable in the context; otherwise, `proxy` will try to fallback to `invoker<void>` without trying to dereference the pointer at runtime.
- Added another 2 unit test cases `ProxyInvocationTests.TestMemberDispatchDefault` and `ProxyInvocationTests.TestFreeDispatchDefault` (converted from previous `ProxyInvocationTests.TestCombinationWithIncompleteDispatch`) to cover this change.

**Validation**

Except for the correctness of the two new macros that can be covered with unit tests, the ultimate goal of this change is to generate better code for default implementation of a dispatch. This has been verified by inspecting the generated code before and after this change.

We came up with the following test code:

```cpp
namespace spec {

std::size_t GetSizeImpl(auto& self) {
  if constexpr (requires { { self.size() } -> std::convertible_to<std::size_t>; }) {
    return self.size();
  } else {
    throw std::runtime_error{"Not implemented"};
  }
}
PRO_DEF_FREE_DISPATCH(size, GetSizeImpl, std::size_t());
PRO_DEF_FACADE(BasicContainer, size);

}  // namespace spec
```

It models a basic container that has a member function `size()`, while throw an exception if it is invoked on an unsupported type. Here is the generated code ([link](https://godbolt.org/z/5s1desKK5)).

![image](https://github.com/microsoft/proxy/assets/12194377/145234c0-6f16-418a-9c0d-013bc0cc0776)

We can see the code for the exception path was duplicated for every type that does not have member function `size()`. With this change, we can use `PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT` instead, with simpler syntax and better code generation ([link](https://godbolt.org/z/WvzE98jbf)).

![image](https://github.com/microsoft/proxy/assets/12194377/549a31e3-6c96-4054-8cf0-865cca457fc8)

Closes #78 