### PR TITLE
Implement make_proxy_inplace and inplace_proxiable_target with freestanding

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -4,7 +4,6 @@
 #ifndef _MSFT_PROXY_
 #define _MSFT_PROXY_
 
-#include <cstring>
 #include <bit>
 #include <concepts>
 #include <initializer_list>
@@ -197,8 +196,9 @@ void copying_dispatcher(char* self, const char* rhs)
 }
 template <std::size_t Len, std::size_t Align>
 void copying_default_dispatcher(char* self, const char* rhs) noexcept {
-  std::memcpy(std::assume_aligned<Align>(self),
-      std::assume_aligned<Align>(rhs), Len);
+  self = std::assume_aligned<Align>(self);
+  rhs = std::assume_aligned<Align>(rhs);
+  for (std::size_t i = 0u; i < Len; ++i) { self[i] = rhs[i]; }
 }
 template <class P>
 void relocation_dispatcher(char* self, const char* rhs)
@@ -698,23 +698,30 @@ constexpr proxiable_ptr_constraints trivial_ptr_constraints{
 namespace details {
 
 template <class T>
-class sbo_ptr {
+class inplace_ptr {
  public:
   template <class... Args>
-  sbo_ptr(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
+  inplace_ptr(Args&&... args)
+      noexcept(std::is_nothrow_constructible_v<T, Args...>)
       requires(std::is_constructible_v<T, Args...>)
       : value_(std::forward<Args>(args)...) {}
-  sbo_ptr(const sbo_ptr&) noexcept(std::is_nothrow_copy_constructible_v<T>)
-      = default;
-  sbo_ptr(sbo_ptr&&) noexcept(std::is_nothrow_move_constructible_v<T>)
-      = default;
+  inplace_ptr(const inplace_ptr&)
+      noexcept(std::is_nothrow_copy_constructible_v<T>) = default;
+  inplace_ptr(inplace_ptr&&)
+      noexcept(std::is_nothrow_move_constructible_v<T>) = default;
 
   T* operator->() const noexcept { return &value_; }
 
  private:
   mutable T value_;
 };
+template <class F, class T, class... Args>
+proxy<F> make_proxy_inplace_impl(Args&&... args) {
+  return proxy<F>{std::in_place_type<inplace_ptr<T>>,
+        std::forward<Args>(args)...};
+}
 
+#if __STDC_HOSTED__
 template <class T, class Alloc>
 static auto rebind_allocator(const Alloc& alloc) {
   return typename std::allocator_traits<Alloc>::template rebind_alloc<T>(alloc);
@@ -761,7 +768,6 @@ class allocated_ptr {
   Alloc alloc_;
   T* ptr_;
 };
-
 template <class T, class Alloc>
 class compact_ptr {
  public:
@@ -782,36 +788,58 @@ class compact_ptr {
   struct storage {
     template <class... Args>
     explicit storage(const Alloc& alloc, Args&&... args)
-        : alloc(alloc), value(std::forward<Args>(args)...) {}
+        : value(std::forward<Args>(args)...), alloc(alloc) {}
 
-    Alloc alloc;
     T value;
+    Alloc alloc;
   };
 
   storage* ptr_;
 };
-
 template <class F, class T, class Alloc, class... Args>
 proxy<F> allocate_proxy_impl(const Alloc& alloc, Args&&... args) {
-  if constexpr (proxiable<details::sbo_ptr<T>, F>) {
-    return proxy<F>{std::in_place_type<details::sbo_ptr<T>>,
-        std::forward<Args>(args)...};
-  } else if constexpr (proxiable<details::allocated_ptr<T, Alloc>, F>) {
-    return proxy<F>{std::in_place_type<details::allocated_ptr<T, Alloc>>,
+  if constexpr (proxiable<allocated_ptr<T, Alloc>, F>) {
+    return proxy<F>{std::in_place_type<allocated_ptr<T, Alloc>>,
         alloc, std::forward<Args>(args)...};
   } else {
-    return proxy<F>{std::in_place_type<details::compact_ptr<T, Alloc>>,
+    return proxy<F>{std::in_place_type<compact_ptr<T, Alloc>>,
         alloc, std::forward<Args>(args)...};
   }
 }
+
 template <class F, class T, class... Args>
 proxy<F> make_proxy_impl(Args&&... args) {
-  return allocate_proxy_impl<F, T>(
-      std::allocator<T>{}, std::forward<Args>(args)...);
+  if constexpr (proxiable<inplace_ptr<T>, F>) {
+    return make_proxy_inplace_impl<F, T>(std::forward<Args>(args)...);
+  } else {
+    return allocate_proxy_impl<F, T>(
+        std::allocator<T>{}, std::forward<Args>(args)...);
+  }
 }
+#endif  // __STDC_HOSTED__
 
 }  // namespace details
 
+template <class T, class F>
+concept inplace_proxiable_target = proxiable<details::inplace_ptr<T>, F>;
+
+template <facade F, inplace_proxiable_target<F> T, class... Args>
+proxy<F> make_proxy_inplace(Args&&... args) {
+  return details::make_proxy_inplace_impl<F, T>(std::forward<Args>(args)...);
+}
+template <facade F, inplace_proxiable_target<F> T, class U, class... Args>
+proxy<F> make_proxy_inplace(std::initializer_list<U> il, Args&&... args) {
+  return details::make_proxy_inplace_impl<F, T>(
+      il, std::forward<Args>(args)...);
+}
+template <facade F, class T>
+    requires(inplace_proxiable_target<std::decay_t<T>, F>)
+proxy<F> make_proxy_inplace(T&& value) {
+  return details::make_proxy_inplace_impl<F, std::decay_t<T>>(
+      std::forward<T>(value));
+}
+
+#if __STDC_HOSTED__
 template <facade F, class T, class Alloc, class... Args>
 proxy<F> allocate_proxy(const Alloc& alloc, Args&&... args) {
   return details::allocate_proxy_impl<F, T>(alloc, std::forward<Args>(args)...);
@@ -827,6 +855,7 @@ proxy<F> allocate_proxy(const Alloc& alloc, T&& value) {
   return details::allocate_proxy_impl<F, std::decay_t<T>>(
       alloc, std::forward<T>(value));
 }
+
 template <facade F, class T, class... Args>
 proxy<F> make_proxy(Args&&... args)
     { return details::make_proxy_impl<F, T>(std::forward<Args>(args)...); }
@@ -837,6 +866,7 @@ template <facade F, class T>
 proxy<F> make_proxy(T&& value) {
   return details::make_proxy_impl<F, std::decay_t<T>>(std::forward<T>(value));
 }
+#endif  // __STDC_HOSTED__
 
 // The following types and macros aim to simplify definition of dispatch and
 // facade types prior to C++26

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,3 +20,13 @@ endif()
 
 include(GoogleTest)
 gtest_discover_tests(msft_proxy_tests)
+
+if(NOT MSVC)
+  add_executable(msft_proxy_freestanding_tests freestanding/proxy_freestanding_tests.cpp)
+  target_include_directories(msft_proxy_freestanding_tests PRIVATE .)
+  target_compile_features(msft_proxy_freestanding_tests PRIVATE cxx_std_20)
+  target_compile_options(msft_proxy_freestanding_tests PRIVATE -Wall -nostdlib -fno-exceptions -fno-rtti -ffreestanding -nostartfiles)
+  target_link_options(msft_proxy_freestanding_tests PRIVATE -nostartfiles)
+  target_link_libraries(msft_proxy_freestanding_tests PRIVATE msft_proxy)
+  add_test(NAME ProxyFreestandingTests COMMAND msft_proxy_freestanding_tests)
+endif()

--- a/tests/freestanding/proxy_freestanding_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_tests.cpp
@@ -65,7 +65,7 @@ extern "C" void _start() {
     "li a7, 93\n"
     "ecall\n"
   );
-#elif defined(__powerpc64__)
+#elif defined(__powerpc64__) || defined(__powerpc__)
   asm(
     "bl main\n"
     "mr 3, 3\n"
@@ -85,13 +85,6 @@ extern "C" void _start() {
     "mov r0, r0\n"
     "mov r7, #1\n"
     "swi #0"
-  );
-#elif defined(__powerpc__)
-  asm(
-    "bl main\n"
-    "mr 3, 3\n"
-    "li 0, 1\n"
-    "sc"
   );
 #else
 #error "Unknown architecture"

--- a/tests/freestanding/proxy_freestanding_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_tests.cpp
@@ -1,0 +1,99 @@
+#include "proxy.h"
+
+unsigned GetHash(int v) { return static_cast<unsigned>(v + 3) * 31; }
+unsigned GetHash(double v) { return static_cast<unsigned>(v * v + 5) * 87; }
+unsigned GetHash(const char* v) {
+  unsigned result = 91u;
+  for (int i = 0; v[i]; ++i) {
+    result = result * 47u + v[i];
+  }
+  return result;
+}
+unsigned GetDefaultHash() { return -1; }
+
+namespace spec {
+
+PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(GetHash, ::GetHash, ::GetDefaultHash, unsigned());
+PRO_DEF_FACADE(Hashable, GetHash);
+
+}  // namespace spec
+
+extern "C" int main() {
+  int i = 123;
+  double d = 3.14159;
+  const char* s = "lalala";
+  std::tuple<int, double> t{11, 22};
+  pro::proxy<spec::Hashable> p;
+  p = &i;
+  if (p() != GetHash(i)) {
+    return 1;
+  }
+  p = &d;
+  if (p() != GetHash(d)) {
+    return 1;
+  }
+  p = pro::make_proxy_inplace<spec::Hashable>(s);
+  if (p() != GetHash(s)) {
+    return 1;
+  }
+  p = &t;
+  if (p() != GetDefaultHash()) {
+    return 1;
+  }
+  return 0;
+}
+
+extern "C" void _start() {
+#if defined(__x86_64__)
+  asm(
+    "call main\n"
+    "mov %eax, %edi\n"
+    "mov $60, %eax\n"
+    "syscall"
+  );
+#elif defined(__aarch64__)
+  asm(
+    "bl main\n"
+    "mov w0, w0\n"
+    "mov w8, #93\n"
+    "svc #0\n"
+  );
+#elif defined(__riscv)
+  asm(
+    "call main\n"
+    "mv a1, a0\n"
+    "li a7, 93\n"
+    "ecall\n"
+  );
+#elif defined(__powerpc64__)
+  asm(
+    "bl main\n"
+    "mr 3, 3\n"
+    "li 0, 1\n"
+    "sc"
+  );
+#elif defined(__i386__)
+  asm(
+    "call main\n"
+    "mov %eax, %ebx\n"
+    "mov $1, %eax\n"
+    "int $0x80"
+  );
+#elif defined(__arm__)
+  asm(
+    "bl main\n"
+    "mov r0, r0\n"
+    "mov r7, #1\n"
+    "swi #0"
+  );
+#elif defined(__powerpc__)
+  asm(
+    "bl main\n"
+    "mr 3, 3\n"
+    "li 0, 1\n"
+    "sc"
+  );
+#else
+#error "Unknown architecture"
+#endif
+}


### PR DESCRIPTION
**Changes**

- Added `concept inplace_proxiable_target` and function templates `make_proxy_inplace` as non-allocating factory. Resolves #86.
- Removed the "in-place" capability from `allocate_proxy` since it makes the semantics ambiguous (will reflect in the documentation later).
- Made the implementation of `proxy` be compatible with freestanding by removing dependency to `memcpy`, which requires C runtime. Fixes #87.
- Excluded `make_proxy` and `allocate_proxy` from freestanding compilation.
- Added unit test cases to cover the new API `make_proxy_inplace` and modified the cases for `allocate_proxy` due to changes in semantics.
- Added a new test case `ProxyFreestandingTests` for freestanding compilation without linking to any static library, using any exceptions, RTTI, or C/C++ runtime. To run the test code from an operating system, some assembly code for various platforms is embedded to invoke in the main function. The code generation on freestanding x86, x86-64, ARM64, RISC-V and PowerPC are tested manually. The pipeline should be able to build and run the test for x84-64. Resolves #88.