### PR TITLE
Add support for custom accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ class Rectangle {
 std::string PrintDrawableToString(pro::proxy<spec::Drawable> p) {
   std::stringstream result;
   result << "shape = ";
-  p.invoke<spec::Draw>(result);
-  result << ", area = " << p.invoke<spec::Area>();
+  p.Draw(result);
+  result << ", area = " << p.Area();
   return std::move(result).str();
 }
 

--- a/proxy.h
+++ b/proxy.h
@@ -24,6 +24,8 @@ struct proxiable_ptr_constraints {
   constraint_level destructibility;
 };
 
+template <class F> class proxy;
+
 namespace details {
 
 struct applicable_traits { static constexpr bool applicable = true; };
@@ -359,6 +361,17 @@ template <class... Ms, class I> requires(!std::is_void_v<I>)
 struct facade_meta_reduction<composite_meta<Ms...>, I>
     : std::type_identity<composite_meta<Ms..., I>> {};
 
+template <class... Ds> struct composite_base : Ds... {};
+template <class P>
+struct base_helper {
+  template <class O, class I> struct reduction : std::type_identity<O> {};
+  template <class... Ds, class I>
+      requires(requires { typename I::template base<P>; } &&
+          std::is_nothrow_default_constructible_v<typename I::template base<P>>)
+  struct reduction<composite_base<Ds...>, I> : std::type_identity<
+      composite_base<Ds..., typename I::template base<P>>> {};
+};
+
 template <class F>
 consteval bool is_facade_constraints_well_formed() {
   if constexpr (is_consteval([] { return F::constraints; })) {
@@ -395,6 +408,8 @@ struct facade_traits_impl<F, Ds...>
       composite_meta<>, copyability_meta, relocatability_meta,
       destructibility_meta, typename dispatch_traits<Ds>::meta...,
       typename F::reflection_type>;
+  using base = recursive_reduction_t<base_helper<proxy<F>>::template reduction,
+      composite_base<>, Ds...>;
 
   template <class D>
   static constexpr bool has_dispatch = (std::is_same_v<D, Ds> || ...);
@@ -454,7 +469,7 @@ concept proxiable = facade<F> && details::ptr_traits<P>::applicable &&
     details::facade_traits<F>::template applicable_ptr<P>;
 
 template <class F>
-class proxy {
+class proxy : public details::facade_traits<F>::base {
   using Traits = details::facade_traits<F>;
   static_assert(Traits::applicable);
   using DefaultDispatch = typename Traits::default_dispatch;
@@ -894,26 +909,34 @@ struct facade_prototype {
 
 }  // namespace pro
 
+#define ___PRO_DIRECT_FUNC_IMPL(__EXPR) \
+    noexcept(noexcept(__EXPR)) requires(requires { __EXPR; }) { return __EXPR; }
 #define ___PRO_DEF_DISPATCH_IMPL(__NAME, __EXPR, __DEFEXPR, __OVERLOADS) \
     struct __NAME { \
      private: \
+      using __D = __NAME; \
       struct __FT { \
         template <class __T, class... __Args> \
         decltype(auto) operator()(__T& __self, __Args&&... __args) \
-            noexcept(noexcept(__EXPR)) requires(requires { __EXPR; }) \
-            { return __EXPR; } \
+            ___PRO_DIRECT_FUNC_IMPL(__EXPR) \
       }; \
       struct __FV { \
         template <class... __Args> \
         decltype(auto) operator()(__Args&&... __args) \
-            noexcept(noexcept(__DEFEXPR)) requires(requires { __DEFEXPR; }) \
-            { return __DEFEXPR; } \
+            ___PRO_DIRECT_FUNC_IMPL(__DEFEXPR) \
       }; \
     \
      public: \
       using overload_types = __OVERLOADS; \
       template <class __T> \
       using invoker = std::conditional_t<std::is_void_v<__T>, __FV, __FT>; \
+      template <class __P> \
+      struct base { \
+        template <class... __Args> \
+        decltype(auto) __NAME(__Args&&... __args) const \
+          ___PRO_DIRECT_FUNC_IMPL(static_cast<const __P*>(this) \
+              ->template invoke<__D>(std::forward<__Args>(__args)...)) \
+      }; \
     }
 #define PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \

--- a/proxy.h
+++ b/proxy.h
@@ -364,14 +364,13 @@ struct facade_meta_reduction<composite_meta<Ms...>, I>
 template <class... As> struct composite_accessor : As... {};
 template <class T>
 struct accessor_helper {
+  template <class D> using accessor = typename D::template accessor<T>;
   template <class O, class I> struct reduction : std::type_identity<O> {};
   template <class... As, class I>
-      requires(requires { typename I::template accessor<T>; } &&
-          std::is_nothrow_default_constructible_v<
-              typename I::template accessor<T>>)
+      requires(requires { typename accessor<I>; } &&
+          std::is_nothrow_default_constructible_v<accessor<I>>)
   struct reduction<composite_accessor<As...>, I>
-      : std::type_identity<composite_accessor<
-            As..., typename I::template accessor<T>>> {};
+      : std::type_identity<composite_accessor<As..., accessor<I>>> {};
 };
 
 template <class F>

--- a/proxy.h
+++ b/proxy.h
@@ -933,31 +933,31 @@ struct facade_prototype {
      public: \
       using overload_types = __OVERLOADS; \
       template <class __T> \
-      using invoker = std::conditional_t<std::is_void_v<__T>, __FV, __FT>; \
+      using invoker = ::std::conditional_t<::std::is_void_v<__T>, __FV, __FT>; \
       template <class __P> \
       struct accessor { \
         template <class... __Args> \
         decltype(auto) __NAME(__Args&&... __args) const \
             ___PRO_DIRECT_FUNC_IMPL((static_cast<::pro::details::dependent_t< \
                 const __P*, __Args...>>(this)->template invoke<__Name>( \
-                std::forward<__Args>(__args)...))) \
+                ::std::forward<__Args>(__args)...))) \
       }; \
     }
 #define PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
-        __self.__FUNC(std::forward<__Args>(__args)...), \
-        __DEFFUNC(std::forward<__Args>(__args)...), std::tuple<__VA_ARGS__>)
+        __self.__FUNC(::std::forward<__Args>(__args)...), \
+        __DEFFUNC(::std::forward<__Args>(__args)...), ::std::tuple<__VA_ARGS__>)
 #define PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
-        __FUNC(__self, std::forward<__Args>(__args)...), \
-        __DEFFUNC(std::forward<__Args>(__args)...), std::tuple<__VA_ARGS__>)
+        __FUNC(__self, ::std::forward<__Args>(__args)...), \
+        __DEFFUNC(::std::forward<__Args>(__args)...), ::std::tuple<__VA_ARGS__>)
 #define PRO_DEF_MEMBER_DISPATCH(__NAME, ...) \
     PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT( \
         __NAME, __NAME, ::pro::details::invalid_call, __VA_ARGS__)
 #define PRO_DEF_FREE_DISPATCH(__NAME, __FUNC, ...) \
     PRO_DEF_FREE_DISPATCH_WITH_DEFAULT( \
         __NAME, __FUNC, ::pro::details::invalid_call, __VA_ARGS__)
-#define PRO_MAKE_DISPATCH_PACK(...) std::tuple<__VA_ARGS__>
+#define PRO_MAKE_DISPATCH_PACK(...) ::std::tuple<__VA_ARGS__>
 #define PRO_DEF_FACADE(__NAME, ...) \
     struct __NAME : ::pro::details::facade_prototype<__VA_ARGS__> {}
 

--- a/proxy.h
+++ b/proxy.h
@@ -369,8 +369,9 @@ struct accessor_helper {
       requires(requires { typename I::template accessor<P>; } &&
           std::is_nothrow_default_constructible_v<
               typename I::template accessor<P>>)
-  struct reduction<composite_accessor<As...>, I> : std::type_identity<
-      composite_accessor<As..., typename I::template accessor<P>>> {};
+  struct reduction<composite_accessor<As...>, I> {
+    using type = composite_accessor<As..., typename I::template accessor<P>>;
+  };
 };
 
 template <class F>

--- a/proxy.h
+++ b/proxy.h
@@ -919,7 +919,7 @@ struct facade_prototype {
 #define ___PRO_DEF_DISPATCH_IMPL(__NAME, __EXPR, __DEFEXPR, __OVERLOADS) \
     struct __NAME { \
      private: \
-      using __D = __NAME; \
+      using __Name = __NAME; \
       struct __FT { \
         template <class __T, class... __Args> \
         decltype(auto) operator()(__T& __self, __Args&&... __args) \
@@ -939,9 +939,9 @@ struct facade_prototype {
       struct accessor { \
         template <class... __Args> \
         decltype(auto) __NAME(__Args&&... __args) const \
-          ___PRO_DIRECT_FUNC_IMPL((static_cast<::pro::details::dependent_t< \
-              const __P*, __Args...>>(this)->template invoke<__D>( \
-              std::forward<__Args>(__args)...))) \
+            ___PRO_DIRECT_FUNC_IMPL((static_cast<::pro::details::dependent_t< \
+                const __P*, __Args...>>(this)->template invoke<__Name>( \
+                std::forward<__Args>(__args)...))) \
       }; \
     }
 #define PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \

--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -13,7 +13,7 @@ PRO_DEF_FACADE(Dictionary, at);
 }  // namespace spec
 
 void demo_print(pro::proxy<spec::Dictionary> dictionary) {
-  std::cout << dictionary(1) << std::endl;
+  std::cout << dictionary.at(1) << std::endl;
 }
 
 int main() {

--- a/tests/freestanding/proxy_freestanding_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_tests.cpp
@@ -29,19 +29,19 @@ extern "C" int main() {
   std::tuple<int, double> t{11, 22};
   pro::proxy<spec::Hashable> p;
   p = &i;
-  if (p() != GetHash(i)) {
+  if (p.GetHash() != GetHash(i)) {
     return 1;
   }
   p = &d;
-  if (p() != GetHash(d)) {
+  if (p.GetHash() != GetHash(d)) {
     return 1;
   }
   p = pro::make_proxy_inplace<spec::Hashable>(s);
-  if (p() != GetHash(s)) {
+  if (p.GetHash() != GetHash(s)) {
     return 1;
   }
   p = &t;
-  if (p() != GetDefaultHash()) {
+  if (p.GetHash() != GetDefaultHash()) {
     return 1;
   }
   return 0;

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -80,7 +80,7 @@ TEST(ProxyCreationTests, TestMakeProxyInplace_FromValue) {
   {
     auto p = pro::make_proxy_inplace<spec::TestLargeStringable>(session);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -95,7 +95,7 @@ TEST(ProxyCreationTests, TestMakeProxyInplace_InPlace) {
   {
     auto p = pro::make_proxy_inplace<spec::TestLargeStringable, utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -110,7 +110,7 @@ TEST(ProxyCreationTests, TestMakeProxyInplace_InPlaceInitializerList) {
   {
     auto p = pro::make_proxy_inplace<spec::TestLargeStringable, utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -127,10 +127,10 @@ TEST(ProxyCreationTests, TestMakeProxyInplace_Lifetime_Copy) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_TRUE(p1.reflect().SboEnabled);
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_TRUE(p2.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -149,7 +149,7 @@ TEST(ProxyCreationTests, TestMakeProxyInplace_Lifetime_Move) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_TRUE(p2.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -167,7 +167,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_FromValue) {
   {
     auto p = pro::allocate_proxy<spec::TestSmallStringable>(std::allocator<void>{}, session);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -183,7 +183,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_InPlace) {
   {
     auto p = pro::allocate_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>(std::allocator<void>{}, & tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
@@ -199,7 +199,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_InPlaceInitializerLis
   {
     auto p = pro::allocate_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>(std::allocator<void>{}, { 1, 2, 3 }, & tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
@@ -217,11 +217,11 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_Lifetime_Copy) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_FALSE(p1.reflect().SboEnabled);
     ASSERT_FALSE(p1.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_FALSE(p2.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -241,7 +241,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_Lifetime_Move) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 1");
+    ASSERT_EQ(p2.ToString(), "Session 1");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_FALSE(p2.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -259,7 +259,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_IndirectAllocator_FromValue) {
     std::pmr::unsynchronized_pool_resource memory_pool;
     auto p = pro::allocate_proxy<spec::TestSmallStringable>(std::pmr::polymorphic_allocator<>{&memory_pool}, session);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_TRUE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -276,7 +276,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_IndirectAllocator_InPlace) {
     std::pmr::unsynchronized_pool_resource memory_pool;
     auto p = pro::allocate_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, & tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_TRUE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
@@ -293,7 +293,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_IndirectAllocator_InPlaceInitializerL
     std::pmr::unsynchronized_pool_resource memory_pool;
     auto p = pro::allocate_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>(std::pmr::polymorphic_allocator<>{&memory_pool}, { 1, 2, 3 }, & tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_TRUE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
@@ -312,11 +312,11 @@ TEST(ProxyCreationTests, TestAllocateProxy_IndirectAllocator_Lifetime_Copy) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_FALSE(p1.reflect().SboEnabled);
     ASSERT_TRUE(p1.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_TRUE(p2.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -337,7 +337,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_IndirectAllocator_Lifetime_Move) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 1");
+    ASSERT_EQ(p2.ToString(), "Session 1");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_TRUE(p2.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -354,7 +354,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithSBO_FromValue) {
   {
     auto p = pro::make_proxy<spec::TestLargeStringable>(session);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -369,7 +369,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithSBO_InPlace) {
   {
     auto p = pro::make_proxy<spec::TestLargeStringable, utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -384,7 +384,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithSBO_InPlaceInitializerList) {
   {
     auto p = pro::make_proxy<spec::TestLargeStringable, utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_TRUE(p.reflect().SboEnabled);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -401,10 +401,10 @@ TEST(ProxyCreationTests, TestMakeProxy_WithSBO_Lifetime_Copy) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_TRUE(p1.reflect().SboEnabled);
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_TRUE(p2.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -423,7 +423,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithSBO_Lifetime_Move) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_TRUE(p2.reflect().SboEnabled);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -441,7 +441,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_FromValue) {
   {
     auto p = pro::make_proxy<spec::TestSmallStringable>(session);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -457,7 +457,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_InPlace) {
   {
     auto p = pro::make_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
@@ -473,7 +473,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_InPlaceInitializerList) {
   {
     auto p = pro::make_proxy<spec::TestSmallStringable, utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_FALSE(p.reflect().SboEnabled);
     ASSERT_FALSE(p.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
@@ -491,11 +491,11 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_Lifetime_Copy) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_FALSE(p1.reflect().SboEnabled);
     ASSERT_FALSE(p1.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_FALSE(p2.reflect().AllocatorAllocatesForItself);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
@@ -515,7 +515,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_Lifetime_Move) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 1");
+    ASSERT_EQ(p2.ToString(), "Session 1");
     ASSERT_FALSE(p2.reflect().SboEnabled);
     ASSERT_FALSE(p2.reflect().AllocatorAllocatesForItself);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -53,8 +53,8 @@ class Point {
 std::string PrintDrawableToString(pro::proxy<spec::Drawable> p) {
   std::stringstream result;
   result << std::fixed << std::setprecision(5) << "shape = ";
-  p.invoke<spec::Draw>(result);
-  result << ", area = " << p.invoke<spec::Area>();
+  p.Draw(result);
+  result << ", area = " << p.Area();
   return std::move(result).str();
 }
 

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -181,6 +181,21 @@ TEST(ProxyInvocationTests, TestRecursiveDefinition) {
   ASSERT_EQ(sum, 21);
 }
 
+TEST(ProxyInvocationTests, TestBase) {
+  std::list<int> l = { 1, 2, 3 };
+  pro::proxy<spec::Container<int>> p = &l;
+  ASSERT_EQ(p.invoke<spec::GetSize>(), 3);
+  int sum = 0;
+  auto accumulate_sum = [&](int x) { sum += x; };
+  p.ForEach(&accumulate_sum);
+  ASSERT_EQ(sum, 6);
+  p.Append(4).Append(5).Append(6);
+  ASSERT_EQ(p.invoke<spec::GetSize>(), 6);
+  sum = 0;
+  p.ForEach(&accumulate_sum);
+  ASSERT_EQ(sum, 21);
+}
+
 TEST(ProxyInvocationTests, TestOverloadResolution) {
   PRO_DEF_FACADE(OverloadedCallable, spec::Call<void(int), void(double), void(const char*), void(char*), void(std::string, int)>);
   std::vector<std::type_index> side_effect;

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -181,16 +181,16 @@ TEST(ProxyInvocationTests, TestRecursiveDefinition) {
   ASSERT_EQ(sum, 21);
 }
 
-TEST(ProxyInvocationTests, TestBase) {
+TEST(ProxyInvocationTests, TestAccessor) {
   std::list<int> l = { 1, 2, 3 };
   pro::proxy<spec::Container<int>> p = &l;
-  ASSERT_EQ(p.invoke<spec::GetSize>(), 3);
+  ASSERT_EQ(p.GetSize(), 3);
   int sum = 0;
   auto accumulate_sum = [&](int x) { sum += x; };
   p.ForEach(&accumulate_sum);
   ASSERT_EQ(sum, 6);
   p.Append(4).Append(5).Append(6);
-  ASSERT_EQ(p.invoke<spec::GetSize>(), 6);
+  ASSERT_EQ(p.GetSize(), 6);
   sum = 0;
   p.ForEach(&accumulate_sum);
   ASSERT_EQ(sum, 21);

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -28,7 +28,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_FromValue) {
   {
     pro::proxy<TestFacade> p = utils::LifetimeTracker::Session(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -65,7 +65,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlace) {
   {
     pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
@@ -97,7 +97,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlaceInitializerList) {
   {
     pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, { 1, 2, 3 }, &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
@@ -131,9 +131,9 @@ TEST(ProxyLifetimeTests, TestCopyConstrction_FromValue) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
@@ -158,7 +158,7 @@ TEST(ProxyLifetimeTests, TestCopyConstrction_FromValue_Exception) {
     }
     ASSERT_TRUE(exception_thrown);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -181,7 +181,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromValue) {
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -243,7 +243,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_ToValue) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 3");
+    ASSERT_EQ(p.ToString(), "Session 3");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
@@ -272,7 +272,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_ToValue_Exception) {
     }
     ASSERT_TRUE(exception_thrown);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
@@ -287,7 +287,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_FromValue_ToNull) {
     pro::proxy<TestFacade> p;
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -328,7 +328,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToValue) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -366,7 +366,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToNull) {
     pro::proxy<TestFacade> p;
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
@@ -402,7 +402,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToValue) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p.emplace<utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 2");
+    ASSERT_EQ(p.ToString(), "Session 2");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -440,7 +440,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToNull) {
     pro::proxy<TestFacade> p;
     p.emplace<utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 1");
+    ASSERT_EQ(p.ToString(), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
@@ -478,9 +478,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToValue) {
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     p1 = p2;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 4");
+    ASSERT_EQ(p1.ToString(), "Session 4");
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kCopyConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(4, utils::LifetimeOperationType::kMoveConstruction);
@@ -510,9 +510,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToValue_Exception) {
     }
     ASSERT_TRUE(exception_thrown);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 1");
+    ASSERT_EQ(p1.ToString(), "Session 1");
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
@@ -535,7 +535,7 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToSelf) {
 #pragma clang diagnostic pop
 #endif  // __clang__
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 3");
+    ASSERT_EQ(p.ToString(), "Session 3");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
@@ -555,9 +555,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToNull) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p1 = p2;
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 3");
+    ASSERT_EQ(p1.ToString(), "Session 3");
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 1");
+    ASSERT_EQ(p2.ToString(), "Session 1");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
@@ -586,7 +586,7 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToNull_Exception) {
     ASSERT_TRUE(exception_thrown);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 1");
+    ASSERT_EQ(p2.ToString(), "Session 1");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -638,7 +638,7 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToValue) {
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     p1 = std::move(p2);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 3");
+    ASSERT_EQ(p1.ToString(), "Session 3");
     ASSERT_FALSE(p2.has_value());
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
@@ -684,7 +684,7 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToNull) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p1 = std::move(p2);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 2");
+    ASSERT_EQ(p1.ToString(), "Session 2");
     ASSERT_FALSE(p2.has_value());
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -740,7 +740,7 @@ TEST(ProxyLifetimeTests, TestHasValue) {
   ASSERT_FALSE(p1.has_value());
   p1 = &foo;
   ASSERT_TRUE(p1.has_value());
-  ASSERT_EQ(p1.invoke(), "123");
+  ASSERT_EQ(p1.ToString(), "123");
 }
 
 TEST(ProxyLifetimeTests, TestReset_FromValue) {
@@ -773,9 +773,9 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Value) {
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     swap(p1, p2);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 4");
+    ASSERT_EQ(p1.ToString(), "Session 4");
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 5");
+    ASSERT_EQ(p2.ToString(), "Session 5");
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(4, utils::LifetimeOperationType::kMoveConstruction);
@@ -797,7 +797,7 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Self) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     swap(p, p);
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(p.invoke(), "Session 3");
+    ASSERT_EQ(p.ToString(), "Session 3");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
@@ -818,7 +818,7 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Null) {
     swap(p1, p2);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
-    ASSERT_EQ(p2.invoke(), "Session 2");
+    ASSERT_EQ(p2.ToString(), "Session 2");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
   }
@@ -835,7 +835,7 @@ TEST(ProxyLifetimeTests, TestSwap_Null_Value) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     swap(p1, p2);
     ASSERT_TRUE(p1.has_value());
-    ASSERT_EQ(p1.invoke(), "Session 2");
+    ASSERT_EQ(p1.ToString(), "Session 2");
     ASSERT_FALSE(p2.has_value());
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);


### PR DESCRIPTION
**Changes**

- Added support for custom base classes potentially using CRTP.
- Added default implementations of base classes for macros `PRO_DEF_*_DISPATCH*` by redirecting the invocation to the `proxy` with the name of the dispatch.
- Added a unit test case for this change, and refactored some other unit test cases with the new feature.