### PR TITLE
Fix helper macros for multiple signatures

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -915,7 +915,7 @@ struct facade_prototype {
 
 #define ___PRO_DIRECT_FUNC_IMPL(__EXPR) \
     noexcept(noexcept(__EXPR)) requires(requires { __EXPR; }) { return __EXPR; }
-#define ___PRO_DEF_DISPATCH_IMPL(__NAME, __EXPR, __DEFEXPR, __OVERLOADS) \
+#define ___PRO_DEF_DISPATCH_IMPL(__NAME, __EXPR, __DEFEXPR, ...) \
     struct __NAME { \
      private: \
       using __Name = __NAME; \
@@ -931,7 +931,7 @@ struct facade_prototype {
       }; \
     \
      public: \
-      using overload_types = __OVERLOADS; \
+      using overload_types = ::std::tuple<__VA_ARGS__>; \
       template <class __T> \
       using invoker = ::std::conditional_t<::std::is_void_v<__T>, __FV, __FT>; \
       template <class __P> \
@@ -946,11 +946,11 @@ struct facade_prototype {
 #define PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
         __self.__FUNC(::std::forward<__Args>(__args)...), \
-        __DEFFUNC(::std::forward<__Args>(__args)...), ::std::tuple<__VA_ARGS__>)
+        __DEFFUNC(::std::forward<__Args>(__args)...), __VA_ARGS__)
 #define PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(__NAME, __FUNC, __DEFFUNC, ...) \
     ___PRO_DEF_DISPATCH_IMPL(__NAME, \
         __FUNC(__self, ::std::forward<__Args>(__args)...), \
-        __DEFFUNC(::std::forward<__Args>(__args)...), ::std::tuple<__VA_ARGS__>)
+        __DEFFUNC(::std::forward<__Args>(__args)...), __VA_ARGS__)
 #define PRO_DEF_MEMBER_DISPATCH(__NAME, ...) \
     PRO_DEF_MEMBER_DISPATCH_WITH_DEFAULT( \
         __NAME, __NAME, ::pro::details::invalid_call, __VA_ARGS__)

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
+#include <format>
 #include <iomanip>
 #include <memory>
 #include <memory_resource>
@@ -18,6 +19,9 @@ namespace spec {
 PRO_DEF_MEMBER_DISPATCH(Draw, void(std::ostream&));
 PRO_DEF_MEMBER_DISPATCH(Area, double() noexcept);
 PRO_DEF_FACADE(Drawable, PRO_MAKE_DISPATCH_PACK(Draw, Area));
+
+PRO_DEF_MEMBER_DISPATCH(Log, void(const char*), void(const char*, const std::exception&));
+PRO_DEF_FACADE(Logger, Log);
 
 }  // namespace spec
 
@@ -106,6 +110,22 @@ pro::proxy<spec::Drawable> MakeDrawableFromCommand(const std::string& s) {
   throw std::runtime_error{"Invalid command"};
 }
 
+class StreamLogger {
+ public:
+  explicit StreamLogger(std::ostream& out) : out_(&out) {}
+  StreamLogger(const StreamLogger&) = default;
+
+  void Log(const char* s) {
+    *out_ << std::format("[INFO] {}\n", s);
+  }
+  void Log(const char* s, const std::exception& e) {
+    *out_ << std::format("[ERROR] {} (exception info: {})\n", s, e.what());
+  }
+
+ private:
+  std::ostream* out_;
+};
+
 }  // namespace
 
 TEST(ProxyIntegrationTests, TestDrawable) {
@@ -126,4 +146,18 @@ TEST(ProxyIntegrationTests, TestDrawable) {
   } catch (const std::runtime_error& e) {
     ASSERT_STREQ(e.what(), "Invalid command");
   }
+}
+
+TEST(ProxyIntegrationTests, TestLogger) {
+  std::ostringstream out;
+  auto logger = pro::make_proxy<spec::Logger, StreamLogger>(out);
+  logger.Log("hello");
+  try {
+    throw std::runtime_error{"runtime error!"};
+  } catch (const std::exception& e) {
+    logger.Log("world", e);
+  }
+  auto content = std::move(out).str();
+  ASSERT_EQ(content, "[INFO] hello\n\
+[ERROR] world (exception info: runtime error!)\n");
 }

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
-#include <format>
 #include <iomanip>
 #include <memory>
 #include <memory_resource>
@@ -116,10 +115,10 @@ class StreamLogger {
   StreamLogger(const StreamLogger&) = default;
 
   void Log(const char* s) {
-    *out_ << std::format("[INFO] {}\n", s);
+    *out_ << "[INFO] " << s << "\n";
   }
   void Log(const char* s, const std::exception& e) {
-    *out_ << std::format("[ERROR] {} (exception info: {})\n", s, e.what());
+    *out_ << "[ERROR] " << s << " (exception info: "  << e.what() << ")\n";
   }
 
  private:


### PR DESCRIPTION
When defining a dispatch with multiple signatures, the behavior is not well-defined in the standard when there are multiple commas (",") in the expansion. This has confirmed to be a regression since 2.3.0.

Resolves #97