### PR TITLE
Fix UB in in-place construction

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -4,6 +4,7 @@
 #ifndef _MSFT_PROXY_
 #define _MSFT_PROXY_
 
+#include <cstddef>
 #include <bit>
 #include <concepts>
 #include <initializer_list>


### PR DESCRIPTION
This PR replaces the current char array used for in-place construction with `std::byte`. This improves code clarity and avoids potential UB.

Fixes #98