### PR TITLE
Remove `concept facade`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -856,14 +856,15 @@ proxy<F> make_proxy_inplace(T&& value)
 
 #if __STDC_HOSTED__
 template <class T, class F>
-concept proxiable_target =
-    proxiable<details::compact_ptr<T, std::allocator<T>>, F>;
+concept allocated_proxiable_target =
+    proxiable<details::compact_ptr<T, std::allocator<void>>, F>;
 
-template <class F, proxiable_target<F> T, class Alloc, class... Args>
+template <class F, allocated_proxiable_target<F> T, class Alloc, class... Args>
 proxy<F> allocate_proxy(const Alloc& alloc, Args&&... args) {
   return details::allocate_proxy_impl<F, T>(alloc, std::forward<Args>(args)...);
 }
-template <class F, proxiable_target<F> T, class Alloc, class U, class... Args>
+template <class F, allocated_proxiable_target<F> T, class Alloc, class U,
+    class... Args>
 proxy<F> allocate_proxy(const Alloc& alloc, std::initializer_list<U> il,
     Args&&... args) {
   return details::allocate_proxy_impl<F, T>(
@@ -874,6 +875,11 @@ proxy<F> allocate_proxy(const Alloc& alloc, T&& value) {
   return details::allocate_proxy_impl<F, std::decay_t<T>>(
       alloc, std::forward<T>(value));
 }
+
+template <class T, class F>
+concept proxiable_target = inplace_proxiable_target<T, F> ||
+    allocated_proxiable_target<T, F>;
+
 template <class F, proxiable_target<F> T, class... Args>
 proxy<F> make_proxy(Args&&... args)
     { return details::make_proxy_impl<F, T>(std::forward<Args>(args)...); }

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -174,7 +174,7 @@ struct FacadeWithTupleLikeDispatches {
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
   using reflection_type = void;
 };
-static_assert(pro::facade<FacadeWithTupleLikeDispatches>);
+static_assert(pro::details::facade_traits<FacadeWithTupleLikeDispatches>::applicable);
 
 struct BadFacade_MissingDispatchTypes {
 #ifdef __clang__
@@ -187,7 +187,7 @@ struct BadFacade_MissingDispatchTypes {
 #endif  // __clang__
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_MissingDispatchTypes>);
+static_assert(!pro::details::facade_traits<BadFacade_MissingDispatchTypes>::applicable);
 
 struct BadFacade_BadDispatchTypes {
   using dispatch_types = int;
@@ -201,20 +201,20 @@ struct BadFacade_BadDispatchTypes {
 #endif  // __clang__
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_BadDispatchTypes>);
+static_assert(!pro::details::facade_traits<BadFacade_BadDispatchTypes>::applicable);
 
 struct BadFacade_MissingConstraints {
   using dispatch_types = std::tuple<>;
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_MissingConstraints>);
+static_assert(!pro::details::facade_traits<BadFacade_MissingConstraints>::applicable);
 
 struct BadFacade_BadConstraints_UnexpectedType {
   using dispatch_types = std::tuple<>;
   static constexpr auto constraints = 0;
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_BadConstraints_UnexpectedType>);
+static_assert(!pro::details::facade_traits<BadFacade_BadConstraints_UnexpectedType>::applicable);
 
 struct BadFacade_BadConstraints_BadAlignment {
   using dispatch_types = std::tuple<>;
@@ -227,7 +227,7 @@ struct BadFacade_BadConstraints_BadAlignment {
   };
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_BadConstraints_BadAlignment>);
+static_assert(!pro::details::facade_traits<BadFacade_BadConstraints_BadAlignment>::applicable);
 
 struct BadFacade_BadConstraints_BadSize {
   using dispatch_types = std::tuple<>;
@@ -240,26 +240,26 @@ struct BadFacade_BadConstraints_BadSize {
   };
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_BadConstraints_BadSize>);
+static_assert(!pro::details::facade_traits<BadFacade_BadConstraints_BadSize>::applicable);
 
 struct BadFacade_BadConstraints_NotConstant {
   using dispatch_types = std::tuple<>;
   static inline const auto constraints = pro::relocatable_ptr_constraints;
   using reflection_type = void;
 };
-static_assert(!pro::facade<BadFacade_BadConstraints_NotConstant>);
+static_assert(!pro::details::facade_traits<BadFacade_BadConstraints_NotConstant>::applicable);
 
 struct BadFacade_MissingReflectionType {
   using dispatch_types = std::tuple<>;
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
 };
-static_assert(!pro::facade<BadFacade_MissingReflectionType>);
+static_assert(!pro::details::facade_traits<BadFacade_MissingReflectionType>::applicable);
 
 struct BadFacade_BadReflectionType {
   using dispatch_types = std::tuple<>;
   static constexpr auto constraints = pro::relocatable_ptr_constraints;
   using reflection_type = std::unique_ptr<int>;  // Probably constexpr, unknown until the evaluation of proxiablility
 };
-static_assert(pro::facade<BadFacade_BadReflectionType>);
+static_assert(pro::details::facade_traits<BadFacade_BadReflectionType>::applicable);
 
 }  // namespace


### PR DESCRIPTION
Since `concept facade` is already shadowed by `concept proxiable`, we have decided to convert it to named requirements in the standard wording. The name `facade` will have new semantics in later changes. This change is planned to be shipped in the next major release of library `proxy`.

With the removal of `concept facade`, two new `concept`s (`allocated_proxiable_target` and `proxiable_target`) are added to improve definition of function templates `allocate_proxy()` and `make_proxy()`.