### PR TITLE
Fix GCC pipeline

### DIFF
--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -15,6 +15,7 @@ jobs:
 
     - name: install gcc
       run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt update
         sudo apt install -y gcc-11 g++-11 gcc-12 g++-12 gcc-13 g++-13
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 1


### PR DESCRIPTION
GCC pipeline was broken due to recent image update of Ubuntu in GitHub Actions. See https://github.com/actions/runner-images/issues/9679 for more details.