### PR TITLE
Simulate overload resolution in macros

### DIFF
--- a/tests/freestanding/proxy_freestanding_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_tests.cpp
@@ -17,7 +17,7 @@ unsigned GetDefaultHash() { return -1; }
 
 namespace spec {
 
-PRO_DEF_FREE_DISPATCH_WITH_DEFAULT(FreeGetHash, GetHash, ::GetHash, ::GetDefaultHash);
+PRO_DEF_FREE_DISPATCH(FreeGetHash, ::GetHash, GetHash, ::GetDefaultHash);
 struct Hashable : pro::facade_builder
     ::add_convention<FreeGetHash, unsigned()>
     ::build {};

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -83,7 +83,7 @@ class LifetimeTracker {
 namespace spec {
 
 using std::to_string;
-PRO_DEF_FREE_DISPATCH(FreeToString, ToString, to_string);
+PRO_DEF_FREE_DISPATCH(FreeToString, to_string, ToString);
 
 struct Stringable : pro::facade_builder
     ::add_convention<FreeToString, std::string()>


### PR DESCRIPTION
The following macros are merged into their siblings without `_WITH_DEFAULT` suffix:

```cpp
PRO_DEF_MEM_DISPATCH_WITH_DEFAULT
PRO_DEF_FREE_DISPATCH_WITH_DEFAULT
PRO_DEF_OPERATOR_DISPATCH_WITH_DEFAULT
PRO_DEF_PREFIX_OPERATOR_DISPATCH_WITH_DEFAULT
PRO_DEF_POSTFIX_OPERATOR_DISPATCH_WITH_DEFAULT
PRO_DEF_CONVERTION_DISPATCH_WITH_DEFAULT
```

The macro `PRO_DEF_MEM_DISPATCH` now accepts 2~4 arguments. The third argument can be specified as the new name of the member function. The forth argument is the default implementation.

Resolves #108
Resolves #109