### PR TITLE
Implement pointer-to-member support

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -412,8 +412,8 @@ struct facade_conv_traits_impl<F, Cs...> : applicable_traits {
   using conv_accessor = composite_accessor<
       F, typename conv_traits<Cs>::dispatch_type...>;
   template <class D, class... Args>
-  using matched_overload = typename conv_traits<first_applicable_t<
-      dispatch_match_helper<D>::template traits, Cs...>>
+  using matched_overload = typename conv_traits<
+      first_applicable_t<dispatch_match_helper<D>::template traits, Cs...>>
       ::template matched_overload<Args...>;
 
   template <class P>

--- a/proxy.h
+++ b/proxy.h
@@ -204,10 +204,11 @@ inline void destruction_default_dispatcher(std::byte*) noexcept {}
 
 template <bool NE, class R, class... Args>
 struct overload_traits_impl : applicable_traits {
+  using dispatcher_type = func_ptr_t<NE, R, const std::byte*, Args...>;
   template <class D>
   struct meta_provider {
     template <class P>
-    static constexpr func_ptr_t<NE, R, const std::byte*, Args...> get() {
+    static constexpr dispatcher_type get() {
       if constexpr (invocable_dispatch<
           D, NE, R, typename ptr_traits<P>::target_type&, Args...>) {
         return &invocation_dispatcher_ref<P, D, R, Args...>;
@@ -223,6 +224,8 @@ struct overload_traits_impl : applicable_traits {
   static constexpr bool applicable_ptr =
       invocable_dispatch_ptr<D, P, NE, R, Args...>;
   static constexpr bool is_noexcept = NE;
+  template <class... Args2>
+  static constexpr bool matches = std::is_invocable_v<resolver, Args2...>;
 };
 template <class O> struct overload_traits : inapplicable_traits {};
 template <class R, class... Args>
@@ -409,8 +412,8 @@ struct facade_conv_traits_impl<F, Cs...> : applicable_traits {
   using conv_accessor = composite_accessor<
       F, typename conv_traits<Cs>::dispatch_type...>;
   template <class D, class... Args>
-  using matched_overload = typename conv_traits<
-      first_applicable_t<dispatch_match_helper<D>::template traits, Cs...>>
+  using matched_overload = typename conv_traits<first_applicable_t<
+      dispatch_match_helper<D>::template traits, Cs...>>
       ::template matched_overload<Args...>;
 
   template <class P>
@@ -516,6 +519,7 @@ class proxy : public details::facade_traits<F>::base {
   friend struct details::proxy_helper<F>;
   using Traits = details::facade_traits<F>;
   static_assert(Traits::applicable);
+  using Meta = typename Traits::meta;
 
   template <class P, class... Args>
   static constexpr bool HasNothrowPolyConstructor = std::conditional_t<
@@ -558,6 +562,44 @@ class proxy : public details::facade_traits<F>::base {
   static constexpr bool HasMoveAssignment = HasMoveConstructor && HasDestructor;
 
  public:
+  template <class O>
+  class dispatch_ptr {
+    using OverloadTraits = details::overload_traits<O>;
+    using DispatcherType = typename OverloadTraits::dispatcher_type;
+
+   public:
+    constexpr dispatch_ptr() noexcept = default;
+    constexpr dispatch_ptr(const dispatch_ptr&) noexcept = default;
+    dispatch_ptr& operator=(const dispatch_ptr&) noexcept = default;
+
+    template <class D>
+    constexpr explicit dispatch_ptr(std::in_place_type_t<D>) noexcept
+#if defined(_MSC_VER) && !defined(__clang__)
+        : offset_(offsetof(Meta, template dispatcher_meta<typename
+              OverloadTraits::template meta_provider<D>>::dispatcher)) {}
+    DispatcherType get_dispatcher(const Meta& meta) const noexcept {
+      return *reinterpret_cast<const DispatcherType*>(
+          reinterpret_cast<const std::byte*>(&meta) + offset_);
+    }
+
+   private:
+    std::size_t offset_;
+#else
+        : ptr_(&details::dispatcher_meta<typename OverloadTraits
+              ::template meta_provider<D>>::dispatcher) {}
+    DispatcherType get_dispatcher(const Meta& meta) const noexcept
+        { return meta.*ptr_; }
+
+   private:
+    DispatcherType Meta::* ptr_;
+#endif  // defined(_MSC_VER) && !defined(__clang__)
+  };
+  template <class D, class... Args>
+  static auto consteval get_dispatch_ptr()
+      requires(requires { typename details::proxy_overload<F, D, Args...>; }) {
+    return dispatch_ptr<details::proxy_overload<F, D, Args...>>{
+        std::in_place_type<D>};
+  }
   proxy() noexcept = default;
   proxy(std::nullptr_t) noexcept : proxy() {}
   proxy(const proxy& rhs) noexcept(HasNothrowCopyConstructor)
@@ -693,16 +735,25 @@ class proxy : public details::facade_traits<F>::base {
     reset();
     return initialize<P>(il, std::forward<Args>(args)...);
   }
+  template <class O>
+  auto operator->*(dispatch_ptr<O> dp) const noexcept {
+    return [this, dp]<class... Args>(Args&&... args)
+        noexcept(details::overload_traits<O>::is_noexcept) -> decltype(auto)
+        requires(details::overload_traits<O>::template matches<Args...>) {
+      return dp.get_dispatcher(*meta_.operator->())(
+          ptr_, std::forward<Args>(args)...);
+    };
+  }
 
  private:
   template <class P, class... Args>
   P& initialize(Args&&... args) {
     std::construct_at(reinterpret_cast<P*>(ptr_), std::forward<Args>(args)...);
-    meta_ = details::meta_ptr<typename Traits::meta>{std::in_place_type<P>};
+    meta_ = details::meta_ptr<Meta>{std::in_place_type<P>};
     return *std::launder(reinterpret_cast<P*>(ptr_));
   }
 
-  details::meta_ptr<typename Traits::meta> meta_;
+  details::meta_ptr<Meta> meta_;
   alignas(F::constraints.max_align) std::byte ptr_[F::constraints.max_size];
 };
 
@@ -711,12 +762,8 @@ decltype(auto) proxy_invoke(const proxy<F>& p, Args&&... args)
     noexcept(details::overload_traits<details::proxy_overload<F, D, Args...>>
         ::is_noexcept)
     requires(requires { typename details::proxy_overload<F, D, Args...>; }) {
-  return details::proxy_helper<F>
-      ::template get_meta<details::dispatcher_meta<
-          typename details::overload_traits<details::proxy_overload<
-              F, D, Args...>>::template meta_provider<D>>>(p)
-      .dispatcher(details::proxy_helper<F>::get_ptr(p),
-          std::forward<Args>(args)...);
+  constexpr auto ptd = proxy<F>::template get_dispatch_ptr<D, Args...>();
+  return (p->*ptd)(std::forward<Args>(args)...);
 }
 
 template <class R, class F>

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable: 4834)  // False alarm from MSVC: warning C4834: discarding return value of function with [[nodiscard]] attribute
-#endif  // _MSC_VER
+#endif  // defined(_MSC_VER) && !defined(__clang__)
 #include "proxy.h"
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif  // _MSC_VER
+#endif  // defined(_MSC_VER) && !defined(__clang__)
 
 namespace {
 

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
+#include <vector>
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable: 4834)  // False alarm from MSVC: warning C4834: discarding return value of function with [[nodiscard]] attribute
@@ -46,6 +47,7 @@ PRO_DEF_OPERATOR_DISPATCH(OpBitwiseXorAssignment, "^=");
 PRO_DEF_OPERATOR_DISPATCH(OpLeftShiftAssignment, "<<=");
 PRO_DEF_OPERATOR_DISPATCH(OpRightShiftAssignment, ">>=");
 PRO_DEF_OPERATOR_DISPATCH(OpComma, ",");
+PRO_DEF_OPERATOR_DISPATCH(OpPtrToMem, "->*");
 PRO_DEF_OPERATOR_DISPATCH(OpArrow, "->");
 PRO_DEF_OPERATOR_DISPATCH(OpParentheses, "()");
 PRO_DEF_OPERATOR_DISPATCH(OpBrackets, "[]");
@@ -72,6 +74,7 @@ PRO_DEF_PREFIX_OPERATOR_DISPATCH(PreOpCaret, "^");
 PRO_DEF_PREFIX_OPERATOR_DISPATCH(PreOpLeftShift, "<<");
 PRO_DEF_PREFIX_OPERATOR_DISPATCH(PreOpRightShift, ">>");
 PRO_DEF_PREFIX_OPERATOR_DISPATCH(PreOpComma, ",");
+PRO_DEF_PREFIX_OPERATOR_DISPATCH(PreOpPtrToMem, "->*");
 
 PRO_DEF_CONVERTION_DISPATCH(ConvertToInt, int);
 
@@ -79,12 +82,20 @@ struct CommaTester {
 public:
   explicit CommaTester(int v) : value_(v) {}
   int operator,(int v) { return value_ + v; }
-  friend int operator,(int v, CommaTester c) { return v * c.value_; }
+  friend int operator,(int v, CommaTester self) { return v * self.value_; }
 
 private:
   int value_;
 };
 
+struct PtrToMemTester {
+public:
+  explicit PtrToMemTester(int v) : value_(v) {}
+  friend int operator->*(int v, PtrToMemTester self) { return v * self.value_; }
+
+private:
+  int value_;
+};
 }  // namespace
 
 TEST(ProxyDispatchTests, TestOpPlus) {
@@ -340,6 +351,28 @@ TEST(ProxyDispatchTests, TestOpComma) {
   ASSERT_EQ((p, 6), 9);
 }
 
+TEST(ProxyDispatchTests, TestOpPtrToMem) {
+  struct Base1 { int a; int b; int c; };
+  struct Base2 { double x; };
+  struct Derived1 : Base1 { int x; };
+  struct Derived2 : Base2, Base1 { int d; };
+  struct TestFacade : pro::facade_builder::add_convention<OpPtrToMem, int&(int Base1::* ptm)>::build {};
+  Derived1 v1{};
+  Derived2 v2{};
+  pro::proxy<TestFacade> p1 = &v1, p2 = &v2;
+  std::vector<int Base1::*> fields{&Base1::a, &Base1::b, &Base1::c};
+  for (int i = 0; i < std::ssize(fields); ++i) {
+    p1->*fields[i] = i + 1;
+    p2->*fields[i] = i + 1;
+  }
+  ASSERT_EQ(v1.a, 1);
+  ASSERT_EQ(v1.b, 2);
+  ASSERT_EQ(v1.c, 3);
+  ASSERT_EQ(v2.a, 1);
+  ASSERT_EQ(v2.b, 2);
+  ASSERT_EQ(v2.c, 3);
+}
+
 TEST(ProxyDispatchTests, TestOpArrow) {
   struct TestFacade : pro::facade_builder::add_convention<OpArrow, const void*()>::build {};
   int v = 12;
@@ -537,6 +570,13 @@ TEST(ProxyDispatchTests, TestPreOpComma) {
   CommaTester v{3};
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ((7, p), 21);
+}
+
+TEST(ProxyDispatchTests, TestPreOpPtrToMem) {
+  struct TestFacade : pro::facade_builder::add_convention<PreOpPtrToMem, int(int val)>::build {};
+  PtrToMemTester v{3};
+  pro::proxy<TestFacade> p = &v;
+  ASSERT_EQ(2->*p, 6);
 }
 
 TEST(ProxyDispatchTests, TestConvertion) {

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -314,3 +314,13 @@ TEST(ProxyInvocationTests, TestObserverDispatch) {
   ASSERT_EQ(ToString(p), "123");
 }
 
+TEST(ProxyInvocationTests, TestPtrToMember) {
+  using Runnable = pro::proxy<spec::Callable<void()>>;
+  constexpr auto OpCallPtr = Runnable::get_dispatch_ptr<spec::OpCall>();
+  static_assert(std::is_same_v<decltype(OpCallPtr), const Runnable::dispatch_ptr<void()>>);
+  int side_effects = 0;
+  auto f = [&] { side_effects = 1; };
+  Runnable p = &f;
+  (p->*OpCallPtr)();
+  ASSERT_EQ(side_effects, 1);
+}


### PR DESCRIPTION
**Changes**

- Added pointer-to-member type `dispatch_ptr` and `consteval` function template `get_dispatch_ptr()` for `proxy`.
- Added overloads of `proxy::operator->*`.
- Added another unit test case for this change.

Here is a comparison table for the syntax of pointer-to-member in direct C++ types and `proxy`:

|Semantics|Direct C++ type `T` (`value` denotes a value of `T`)|`proxy` type `P` (`value` denotes a value of `P`)|
|--|--|--|
|Pointer-to-member type (function)|`R (T::*)(Args...)`|`P::dispatch_ptr<R(Args...)>`|
|Pointer-to-member type (field)|`M T::*`|N/A|
|Acquire pointer-to-member (function template)|`&T::member<Args...>`|`P::get_dispatch_ptr<Args...>`|
|Invoke member function with pointer-to-member `ptr`|`(value.*ptr)(args...)`|`(p->*ptr)(args...)`|

Note that we cannot use pointer-to-member in multiple inheritance today in MSVC due to [a bug](https://developercommunity.visualstudio.com/t/Pointer-to-member-is-incorrect-in-consta/10676335) in the compiler implementation. Therefore, we fallback the implementation for MSVC to C-style `offsetof`. Interestingly, `offsetof` won't compile in GCC or clang in our scenario (probably we hit some limitations in macro expansion), but we have not investigated further while pointer-to-member works as expected in the two compilers.

Resolves #107