### PR TITLE
Revise semantics of `proxiable_ptr_constraints`

### DIFF
--- a/samples/resource_dictionary/main.cpp
+++ b/samples/resource_dictionary/main.cpp
@@ -1,27 +1,27 @@
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <proxy/proxy.h>
 
-namespace spec {
-
 PRO_DEF_MEM_DISPATCH(MemAt, at);
+
 struct Dictionary : pro::facade_builder
     ::add_convention<MemAt, std::string(int)>
     ::build {};
 
-}  // namespace spec
-
-void demo_print(pro::proxy<spec::Dictionary> dictionary) {
-  std::cout << dictionary->at(1) << std::endl;
+// This is a function, rather than a function template
+void PrintDictionary(pro::proxy<Dictionary> dictionary) {
+  std::cout << dictionary->at(1) << "\n";
 }
 
 int main() {
-  std::map<int, std::string> container1{{1, "hello"}};
-  std::vector<std::string> container2{"hello", "world"};
-  demo_print(&container1);  // print: hello\n
-  demo_print(&container2);  // print: world\n
-  return 0;
+  static std::map<int, std::string> container1{{1, "hello"}};
+  auto container2 = std::make_shared<std::vector<const char*>>();
+  container2->push_back("hello");
+  container2->push_back("world");
+  PrintDictionary(&container1);  // prints: hello\n
+  PrintDictionary(container2);  // prints: world\n
 }

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -208,7 +208,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromValue_Trivial) {
     pro::proxy<TestTrivialFacade> p1 = &session;
     ASSERT_TRUE(p1.has_value());
     auto p2 = std::move(p1);
-    ASSERT_FALSE(p1.has_value());
+    ASSERT_TRUE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 1");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -544,14 +544,10 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToSelf) {
 #pragma clang diagnostic pop
 #endif  // __clang__
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(ToString(*p), "Session 3");
-    expected_ops.emplace_back(2, utils::LifetimeOperationType::kCopyConstruction);
-    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
-    expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
-    expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+    ASSERT_EQ(ToString(*p), "Session 1");
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
-  expected_ops.emplace_back(3, utils::LifetimeOperationType::kDestruction);
+  expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -133,9 +133,9 @@ struct TrivialFacade : pro::facade_builder
 static_assert(std::is_trivially_copy_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_copy_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);
-static_assert(!std::is_trivially_move_constructible_v<pro::proxy<TrivialFacade>>);
+static_assert(std::is_trivially_move_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_nothrow_move_assignable_v<pro::proxy<TrivialFacade>>);
-static_assert(!std::is_trivially_move_assignable_v<pro::proxy<TrivialFacade>>);
+static_assert(std::is_trivially_move_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_destructible_v<pro::proxy<TrivialFacade>>);
 static_assert(!pro::proxiable<MockMovablePtr, TrivialFacade>);
 static_assert(!pro::proxiable<MockCopyablePtr, TrivialFacade>);


### PR DESCRIPTION
**Changes**

- Updated the requirements of `constraint_level::trivial` in `proxiable_ptr_constraints` from `std::is_trivially_copy_constructible_v<T>` into `std::is_trivially_copy_constructible_v<T> && std::is_trivially_destructible_v<T>` to align with the definition of [`std::is_trivially_copyable`](https://en.cppreference.com/w/cpp/types/is_trivially_copyable).
- In class template `proxy<F>`, removed `proxy::proxy(const proxy&) = delete`, `proxy::proxy(proxy&&) = delete`, `proxy& proxy::operator=(const proxy&) = delete`, `proxy& proxy::operator=(proxy&&) = delete` and `proxy::~proxy() = delete` since they are no longer needed.
- In class template `proxy<F>`, when `F::constraints::copyability == constraint_level::trivial`, `proxy(proxy&&)` and `proxy& operator=(proxy&&)` are no longer defined, so that move constructions and move assignments can fall back to trivial implementations of `proxy(const proxy&) noexcept = default` and `proxy& operator=(const proxy&) noexcept = default`.
- In class template `proxy<F>`, merged `proxy& operator=(const proxy&)` and `proxy& operator=(const proxy&) noexcept`; merged `proxy& operator=(P&& ptr)` and `proxy& operator=(P&& ptr) noexcept`.
- Moved friend function `swap` from `proxy<F>` into global namespace `pro` and removed the `requires` clause.
- Explicitly declared return types of function template `access_proxy`.
- Updated sample code for resource dictionary.
- Updated unit tests accordingly.