### PR TITLE
Improve API design

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -704,6 +704,7 @@ class proxy : public details::facade_traits<F>::direct_accessor {
   }
 
   bool has_value() const noexcept { return meta_.has_value(); }
+  explicit operator bool() const noexcept { return meta_.has_value(); }
   void reset()
       noexcept(F::constraints.destructibility >= constraint_level::nothrow)
       requires(F::constraints.destructibility >= constraint_level::nontrivial)

--- a/proxy.h
+++ b/proxy.h
@@ -759,6 +759,11 @@ class proxy : public details::facade_traits<F>::direct_accessor {
   auto&& operator*() const&& noexcept requires(_Traits::has_indirection)
       { return std::forward<const typename _Traits::indirect_accessor>(ia_); }
 
+  friend void swap(proxy& lhs, proxy& rhs) noexcept(noexcept(lhs.swap(rhs)))
+      { lhs.swap(rhs); }
+  friend bool operator==(const proxy& lhs, std::nullptr_t) noexcept
+      { return !lhs.has_value(); }
+
  private:
   template <class P, class... Args>
   P& initialize(Args&&... args) {
@@ -820,9 +825,6 @@ const proxy<F>&& access_proxy(const A&& a) noexcept {
 template <class R, class F>
 const R& proxy_reflect(const proxy<F>& p) noexcept
     { return details::proxy_helper<F>::get_meta(p); }
-
-template <class F>
-void swap(proxy<F>& a, proxy<F>& b) noexcept(noexcept(a.swap(b))) { a.swap(b); }
 
 namespace details {
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -748,6 +748,15 @@ TEST(ProxyLifetimeTests, TestHasValue) {
   ASSERT_EQ(ToString(*p1), "123");
 }
 
+TEST(ProxyLifetimeTests, TestEqualsToNullptr) {
+  int foo = 123;
+  pro::proxy<TestFacade> p1;
+  ASSERT_TRUE(p1 == nullptr);
+  p1 = &foo;
+  ASSERT_TRUE(p1 != nullptr);
+  ASSERT_EQ(ToString(*p1), "123");
+}
+
 TEST(ProxyLifetimeTests, TestReset_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -752,8 +752,10 @@ TEST(ProxyLifetimeTests, TestEqualsToNullptr) {
   int foo = 123;
   pro::proxy<TestFacade> p1;
   ASSERT_TRUE(p1 == nullptr);
+  ASSERT_TRUE(nullptr == p1);
   p1 = &foo;
   ASSERT_TRUE(p1 != nullptr);
+  ASSERT_TRUE(nullptr != p1);
   ASSERT_EQ(ToString(*p1), "123");
 }
 

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -748,6 +748,18 @@ TEST(ProxyLifetimeTests, TestHasValue) {
   ASSERT_EQ(ToString(*p1), "123");
 }
 
+TEST(ProxyLifetimeTests, TestOperatorBool) {
+  // Implicit conversion to bool shall be prohibited.
+  static_assert(!std::is_nothrow_convertible_v<pro::proxy<TestFacade>, bool>);
+
+  int foo = 123;
+  pro::proxy<TestFacade> p1;
+  ASSERT_FALSE(static_cast<bool>(p1));
+  p1 = &foo;
+  ASSERT_TRUE(static_cast<bool>(p1));
+  ASSERT_EQ(ToString(*p1), "123");
+}
+
 TEST(ProxyLifetimeTests, TestEqualsToNullptr) {
   int foo = 123;
   pro::proxy<TestFacade> p1;


### PR DESCRIPTION
**Changes**

- Moved function `swap` back to the definition of `proxy`, since overloading the global `swap` is no longer recommended after C++20.
- Added friend function `bool operator==` similar with [`std::move_only_function`](https://en.cppreference.com/w/cpp/utility/functional/move_only_function/operator%3D%3D).
- Added a unit test case to cover the change.