### PR TITLE
Make `facade_builder` a class type, rather than a type alias

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -1159,13 +1159,13 @@ struct facade_builder_impl {
 
 }  // namespace details
 
-using facade_builder = details::facade_builder_impl<std::tuple<>, std::tuple<>,
+struct facade_builder : details::facade_builder_impl<std::tuple<>, std::tuple<>,
     proxiable_ptr_constraints{
         .max_size = details::invalid_size,
         .max_align = details::invalid_size,
         .copyability = details::invalid_cl,
         .relocatability = details::invalid_cl,
-        .destructibility = details::invalid_cl}>;
+        .destructibility = details::invalid_cl}> {};
 
 #define ___PRO_DIRECT_FUNC_IMPL(...) \
     noexcept(noexcept(__VA_ARGS__)) requires(requires { __VA_ARGS__; }) \


### PR DESCRIPTION
As a documented class type, `facade_builder` shall not be a type alias. No behavior changes.