### PR TITLE
Improve code quality

### DIFF
--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -27,7 +27,8 @@ struct SboObserver {
 namespace spec {
 
 struct TestLargeStringable : pro::facade_builder
-    ::add_facade<utils::spec::Stringable>
+    ::add_convention<utils::spec::FreeToString, std::string()>
+    ::support_relocation<pro::constraint_level::nontrivial>
     ::support_copy<pro::constraint_level::nontrivial>
     ::add_reflection<SboObserver>
     ::build {};

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -672,6 +672,7 @@ TEST(ProxyDispatchTests, TestDirectConversion) {
   pro::proxy<TestFacade> p1 = std::make_unique<int>(123);
   *p1 += 3;
   pro::proxy<TestFacadeBase> p2 = static_cast<pro::proxy<TestFacadeBase>>(std::move(p1));
+  ASSERT_FALSE(p1.has_value());
   std::ostringstream stream;
   stream << *p2;
   ASSERT_EQ(stream.str(), "126");

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -7,9 +7,13 @@
 
 namespace {
 
+PRO_DEF_CONVERSION_DISPATCH(ConvertToSession, utils::LifetimeTracker::Session);
+
 struct TestFacade : pro::facade_builder
-    ::add_facade<utils::spec::Stringable>
+    ::add_convention<utils::spec::FreeToString, std::string()>
+    ::support_relocation<pro::constraint_level::nontrivial>
     ::support_copy<pro::constraint_level::nontrivial>
+    ::add_direct_convention<ConvertToSession, utils::LifetimeTracker::Session() const&, utils::LifetimeTracker::Session()&&>
     ::build {};
 
 struct TestTrivialFacade : pro::facade_builder
@@ -17,13 +21,6 @@ struct TestTrivialFacade : pro::facade_builder
     ::support_copy<pro::constraint_level::trivial>
     ::support_relocation<pro::constraint_level::trivial>
     ::support_destruction<pro::constraint_level::trivial>
-    ::build {};
-
-PRO_DEF_CONVERSION_DISPATCH(ConvertToSession, utils::LifetimeTracker::Session);
-
-struct TestConvertionFacade : pro::facade_builder
-    ::add_facade<utils::spec::Stringable>
-    ::add_direct_convention<ConvertToSession, utils::LifetimeTracker::Session() const&, utils::LifetimeTracker::Session() && noexcept>
     ::build {};
 
 }  // namespace
@@ -259,14 +256,16 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_ToValue) {
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(ToString(*p), "Session 3");
+    ASSERT_EQ(ToString(*p), "Session 4");
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
-    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+    expected_ops.emplace_back(4, utils::LifetimeOperationType::kMoveConstruction);
+    expected_ops.emplace_back(3, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
-  expected_ops.emplace_back(3, utils::LifetimeOperationType::kDestruction);
+  expected_ops.emplace_back(4, utils::LifetimeOperationType::kDestruction);
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
@@ -303,13 +302,15 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_FromValue_ToNull) {
     pro::proxy<TestFacade> p;
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
-    ASSERT_EQ(ToString(*p), "Session 2");
+    ASSERT_EQ(ToString(*p), "Session 3");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kMoveConstruction);
+    expected_ops.emplace_back(3, utils::LifetimeOperationType::kMoveConstruction);
+    expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
-  expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+  expected_ops.emplace_back(3, utils::LifetimeOperationType::kDestruction);
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
@@ -661,6 +662,32 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToValue) {
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
+TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToValue_Exception) {
+  utils::LifetimeTracker tracker;
+  std::vector<utils::LifetimeOperation> expected_ops;
+  {
+    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
+    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
+    tracker.ThrowOnNextConstruction();
+    bool exception_thrown = false;
+    try {
+      p1 = std::move(p2);
+    } catch (const utils::ConstructionFailure& e) {
+      exception_thrown = true;
+      ASSERT_EQ(e.type_, utils::LifetimeOperationType::kMoveConstruction);
+    }
+    ASSERT_TRUE(exception_thrown);
+    ASSERT_FALSE(p1.has_value());
+    ASSERT_FALSE(p2.has_value());
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+    expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+    ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+  }
+  ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+}
+
 TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToSelf) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
@@ -703,6 +730,30 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToNull) {
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+  ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+}
+
+TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToNull_Exception) {
+  utils::LifetimeTracker tracker;
+  std::vector<utils::LifetimeOperation> expected_ops;
+  {
+    pro::proxy<TestFacade> p1;
+    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
+    tracker.ThrowOnNextConstruction();
+    bool exception_thrown = false;
+    try {
+      p1 = std::move(p2);
+    } catch (const utils::ConstructionFailure& e) {
+      exception_thrown = true;
+      ASSERT_EQ(e.type_, utils::LifetimeOperationType::kMoveConstruction);
+    }
+    ASSERT_TRUE(exception_thrown);
+    ASSERT_FALSE(p1.has_value());
+    ASSERT_FALSE(p2.has_value());
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+    ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+  }
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
@@ -897,7 +948,7 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Lvalue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestConvertionFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto session = static_cast<utils::LifetimeTracker::Session>(p);
     ASSERT_TRUE(p.has_value());
@@ -915,7 +966,7 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Rvalue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestConvertionFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto session = static_cast<utils::LifetimeTracker::Session>(std::move(p));
     ASSERT_FALSE(p.has_value());
@@ -925,5 +976,27 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Rvalue) {
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(2, utils::LifetimeOperationType::kDestruction);
+  ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+}
+
+TEST(ProxyLifetimeTests, Test_DirectConvension_Rvalue_Exception) {
+  utils::LifetimeTracker tracker;
+  std::vector<utils::LifetimeOperation> expected_ops;
+  {
+    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
+    tracker.ThrowOnNextConstruction();
+    bool exception_thrown = false;
+    try {
+      auto session = static_cast<utils::LifetimeTracker::Session>(std::move(p));
+    } catch (const utils::ConstructionFailure& e) {
+      exception_thrown = true;
+      ASSERT_EQ(e.type_, utils::LifetimeOperationType::kMoveConstruction);
+    }
+    ASSERT_TRUE(exception_thrown);
+    ASSERT_FALSE(p.has_value());
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+    ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+  }
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -50,7 +50,7 @@ class LifetimeTracker {
     Session(const Session& rhs)
         : id_(rhs.host_->AllocateId(LifetimeOperationType::kCopyConstruction)),
           host_(rhs.host_) {}
-    Session(Session&& rhs) noexcept :
+    Session(Session&& rhs) :
           id_(rhs.host_->AllocateId(LifetimeOperationType::kMoveConstruction)),
           host_(rhs.host_) {}
     ~Session() { host_->ops_.emplace_back(id_, LifetimeOperationType::kDestruction); }


### PR DESCRIPTION
**Changes**

- Resolved #122: Calling a polymorphic function with a rvalue-reference convention shall be destructive. Added unit tests accordingly.
- Reverted #129: Unfortunately, this change makes Visual Studio IntelliSense unhappy again. Revert for now.
- Declared the default constructor of `facade_builder_impl` as `deleted`.
- Renamed `pro::details::facade_builder_impl` into `pro::basic_facade_builder` as a public API.