### PR TITLE
Revise `pro::facade_builder::restrict_layout`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -1104,6 +1104,10 @@ consteval auto merge_constraints(proxiable_ptr_constraints a,
   a = make_destructible(a, b.destructibility);
   return a;
 }
+consteval std::size_t max_align_of(std::size_t value) {
+  value &= ~value + 1u;
+  return value < alignof(std::max_align_t) ? value : alignof(std::max_align_t);
+}
 
 template <bool IS_DIRECT, class D, class... Os>
 struct conv_impl {
@@ -1184,8 +1188,8 @@ struct basic_facade_builder {
       details::merge_conv_tuple_t<Cs, typename F::convention_types>,
       details::merge_tuple_t<Rs, typename F::reflection_types>,
       details::merge_constraints(C, F::constraints)>;
-  template <std::size_t PtrSize, std::size_t PtrAlign =
-      PtrSize < alignof(std::max_align_t) ? PtrSize : alignof(std::max_align_t)>
+  template <std::size_t PtrSize,
+      std::size_t PtrAlign = details::max_align_of(PtrSize)>
       requires(std::has_single_bit(PtrAlign) && PtrSize % PtrAlign == 0u)
   using restrict_layout = basic_facade_builder<
       Cs, Rs, details::make_restricted_layout(C, PtrSize, PtrAlign)>;

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -330,4 +330,11 @@ struct BigFacade : pro::facade_builder
     ::build {};
 static_assert(sizeof(pro::proxy<BigFacade>) == 3 * sizeof(void*));  // Accessors should not add paddings
 
+struct FacadeWithSizeOfNonPowerOfTwo : pro::facade_builder
+    ::restrict_layout<6u>
+    ::build {};
+static_assert(pro::facade<FacadeWithSizeOfNonPowerOfTwo>);
+static_assert(FacadeWithSizeOfNonPowerOfTwo::constraints.max_size == 6u);
+static_assert(FacadeWithSizeOfNonPowerOfTwo::constraints.max_align == 2u);
+
 }  // namespace


### PR DESCRIPTION
Before this change `restrict_layout` only supports sizes that are power of two to omit alignments, or a hard error will be encountered.

Resolves #131 
