### PR TITLE
Remove redundant semicolon

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -1533,7 +1533,7 @@ struct conversion_dispatch {
       template <class... __Args> \
       decltype(auto) operator()(::std::nullptr_t, __Args&&... __args) \
           ___PRO_DIRECT_FUNC_IMPL(__FUNC(::std::forward<__Args>(__args)...)) \
-    };
+    }
 
 }  // namespace pro
 


### PR DESCRIPTION
Macro `PRO_DEF_WEAK_DISPATCH` should not define the semicolon at the end of its definition. No functional changes.