### PR TITLE
Fix build error

### DIFF
--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -20,7 +20,6 @@ jobs:
 
     - name: build and run test with AppleClang
       run: |
-        cmake . -B build
-        cmake --build ./build -j8
-        cd ./build
-        ctest -j8
+        cmake -B build
+        cmake --build build -j
+        ctest --test-dir build -j

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -22,14 +22,6 @@ jobs:
         sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" -y
         sudo apt update
         sudo apt install -y clang-15 clang-16 clang-17 clang-18
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-15 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-15 1
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-16 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-16 1
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-17 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-17 1
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-18 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-18 1
 
     - name: check compiler versions
       run: |
@@ -40,36 +32,24 @@ jobs:
 
     - name: build and run test with clang 15
       run: |
-        sudo update-alternatives --set gcc /usr/bin/clang-15
-        sudo update-alternatives --set g++ /usr/bin/clang++-15
-        cmake . -B build-clang-15
-        cmake --build ./build-clang-15 -j8
-        cd ./build-clang-15
-        ctest -j8
+        cmake -B build-clang-15 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15
+        cmake --build build-clang-15 -j
+        ctest --test-dir build-clang-15 -j
 
     - name: build and run test with clang 16
       run: |
-        sudo update-alternatives --set gcc /usr/bin/clang-16
-        sudo update-alternatives --set g++ /usr/bin/clang++-16
-        cmake . -B build-clang-16
-        cmake --build ./build-clang-16 -j8
-        cd ./build-clang-16
-        ctest -j8
+        cmake -B build-clang-16 -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16
+        cmake --build build-clang-16 -j
+        ctest --test-dir build-clang-16 -j
 
     - name: build and run test with clang 17
       run: |
-        sudo update-alternatives --set gcc /usr/bin/clang-17
-        sudo update-alternatives --set g++ /usr/bin/clang++-17
-        cmake . -B build-clang-17
-        cmake --build ./build-clang-17 -j8
-        cd ./build-clang-17
-        ctest -j8
+        cmake -B build-clang-17 -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17
+        cmake --build build-clang-17 -j
+        ctest --test-dir build-clang-17 -j
 
     - name: build and run test with clang 18
       run: |
-        sudo update-alternatives --set gcc /usr/bin/clang-18
-        sudo update-alternatives --set g++ /usr/bin/clang++-18
-        cmake . -B build-clang-18
-        cmake --build ./build-clang-18 -j8
-        cd ./build-clang-18
-        ctest -j8
+        cmake -B build-clang-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18
+        cmake --build build-clang-18 -j
+        ctest --test-dir build-clang-18 -j

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -18,12 +18,6 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt update
         sudo apt install -y gcc-11 g++-11 gcc-12 g++-12 gcc-13 g++-13
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 1
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 1
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1
 
     - name: check compiler versions
       run: |
@@ -33,27 +27,18 @@ jobs:
 
     - name: build and run test with gcc 11
       run: |
-        sudo update-alternatives --set gcc /usr/bin/gcc-11
-        sudo update-alternatives --set g++ /usr/bin/g++-11
-        cmake . -B build-gcc-11
-        cmake --build ./build-gcc-11 -j8
-        cd ./build-gcc-11
-        ctest -j8
+        cmake -B build-gcc-11 -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+        cmake --build build-gcc-11 -j
+        ctest --test-dir build-gcc-11 -j
 
     - name: build and run test with gcc 12
       run: |
-        sudo update-alternatives --set gcc /usr/bin/gcc-12
-        sudo update-alternatives --set g++ /usr/bin/g++-12
-        cmake . -B build-gcc-12
-        cmake --build ./build-gcc-12 -j8
-        cd ./build-gcc-12
-        ctest -j8
+        cmake -B build-gcc-12 -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
+        cmake --build build-gcc-12 -j
+        ctest --test-dir build-gcc-12 -j
 
     - name: build and run test with gcc 13
       run: |
-        sudo update-alternatives --set gcc /usr/bin/gcc-13
-        sudo update-alternatives --set g++ /usr/bin/g++-13
-        cmake . -B build-gcc-13
-        cmake --build ./build-gcc-13 -j8
-        cd ./build-gcc-13
-        ctest -j8
+        cmake -B build-gcc-13 -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
+        cmake --build build-gcc-13 -j
+        ctest --test-dir build-gcc-13 -j

--- a/.github/workflows/bvt-msvc.yml
+++ b/.github/workflows/bvt-msvc.yml
@@ -15,10 +15,9 @@ jobs:
 
     - name: build with cmake
       run: |
-        cmake . -B build
-        cmake --build ./build -j8
+        cmake -B build
+        cmake --build build -j
 
     - name: run tests
       run: |
-        cd ./build
-        ctest -j8
+        ctest --test-dir build -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required(VERSION 3.5)
 
 project(msft_proxy
         VERSION 0.1.0 # local build version
@@ -27,11 +27,14 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/proxyConfigVersion.cmake
 include(CTest)
 if (BUILD_TESTING)
   include(FetchContent)
-  # gtest version release-1.15.2
+  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+  # allows for proper rebuilds when a projects URL changes.
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+  endif()
   FetchContent_Declare(
     googletest
-    URL https://github.com/google/googletest/archive/b514bdc898e2951020cbdca1304b75f5950d1f59.zip
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
   )
 
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/README.md
+++ b/README.md
@@ -183,10 +183,9 @@ cmake <source_dir> -B <build_dir> -DCMAKE_TOOLCHAIN_FILE=<vcpkg_dir>/scripts/bui
 ```
 git clone https://github.com/microsoft/proxy.git
 cd proxy
-cmake -S . -B build
-cmake --build ./build -j8
-cd ./build
-ctest -j8
+cmake -B build
+cmake --build build -j
+ctest --test-dir build -j8
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ git clone https://github.com/microsoft/proxy.git
 cd proxy
 cmake -B build
 cmake --build build -j
-ctest --test-dir build -j8
+ctest --test-dir build -j
 ```
 
 ## Contributing


### PR DESCRIPTION
**Changes**

- Only enable [CMP0135](https://cmake.org/cmake/help/latest/policy/CMP0135.html) when the policy is available. Resolves #154
- Updated the download URL of google test to the public one.
- Simplify scripts to invoke CMake with various C++ compilers without creating aliases.
- Updated README accordingly.