### PR TITLE
Add support for upward conversion in `facade_builder::add_facade`

### DIFF
--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -21,15 +21,14 @@ struct TestTrivialFacade : pro::facade_builder
     ::support_destruction<pro::constraint_level::trivial>
     ::build {};
 
-struct TestRelocatableFacade : pro::facade_builder
-    ::add_convention<utils::spec::FreeToString, std::string()>
-    ::support_relocation<pro::constraint_level::nontrivial>
-    ::build {};
-
 struct TestRttiFacade : pro::facade_builder
     ::add_reflection<utils::RttiReflection>
     ::add_facade<TestFacade, true>
     ::build {};
+
+// Additional static asserts for upward conversion
+static_assert(!std::is_convertible_v<pro::proxy<TestTrivialFacade>, pro::proxy<utils::spec::Stringable>>);
+static_assert(std::is_convertible_v<pro::proxy<TestRttiFacade>, pro::proxy<TestFacade>>);
 
 }  // namespace
 
@@ -1037,7 +1036,6 @@ TEST(ProxyLifetimeTests, Test_UpwardCopyConvension_FromNull) {
 }
 
 TEST(ProxyLifetimeTests, Test_UpwardMoveConvension_FromValue) {
-
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -5,20 +5,9 @@
 #include <memory>
 #include <typeinfo>
 #include "proxy.h"
+#include "utils.h"
 
 namespace {
-
-class RttiReflection {
- public:
-  template <class T>
-  constexpr explicit RttiReflection(std::in_place_type_t<T>)
-      : type_(typeid(T)) {}
-
-  const char* GetName() const noexcept { return type_.name(); }
-
- private:
-  const std::type_info& type_;
-};
 
 struct TraitsReflection {
  public:
@@ -38,7 +27,7 @@ struct TraitsReflection {
 };
 
 struct TestRttiFacade : pro::facade_builder
-    ::add_reflection<RttiReflection>
+    ::add_reflection<utils::RttiReflection>
     ::build {};
 
 struct TestTraitsFacade : pro::facade_builder
@@ -50,12 +39,12 @@ struct TestTraitsFacade : pro::facade_builder
 TEST(ProxyReflectionTests, TestRtti_RawPtr) {
   int foo = 123;
   pro::proxy<TestRttiFacade> p = &foo;
-  ASSERT_STREQ(pro::proxy_reflect<RttiReflection>(p).GetName(), typeid(int*).name());
+  ASSERT_STREQ(pro::proxy_reflect<utils::RttiReflection>(p).GetName(), typeid(int*).name());
 }
 
 TEST(ProxyReflectionTests, TestRtti_FancyPtr) {
   pro::proxy<TestRttiFacade> p = std::make_unique<double>(1.23);
-  ASSERT_STREQ(pro::proxy_reflect<RttiReflection>(p).GetName(), typeid(std::unique_ptr<double>).name());
+  ASSERT_STREQ(pro::proxy_reflect<utils::RttiReflection>(p).GetName(), typeid(std::unique_ptr<double>).name());
 }
 
 TEST(ProxyReflectionTests, TestTraits_RawPtr) {

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -92,6 +92,18 @@ struct Stringable : pro::facade_builder
 
 }  // namespace spec
 
+class RttiReflection {
+ public:
+  template <class T>
+  constexpr explicit RttiReflection(std::in_place_type_t<T>)
+      : type_(typeid(T)) {}
+
+  const char* GetName() const noexcept { return type_.name(); }
+
+ private:
+  const std::type_info& type_;
+};
+
 }  // namespace utils
 
 #endif  // _MSFT_PROXY_TEST_UTILS_


### PR DESCRIPTION
By default, `facade_builder::add_facade` does not generate conventions for implicit upward conversion to guarantee minimum binary size. However, upward conversion is helpful when an API requires backward compatibility. With this change, users can opt-in this feature by specifying `true` as the second parameter of `facade_builder::add_facade`, at the cost of potentially a little bit larger binary size.

4 unit test cases are added for this change.