### PR TITLE
Fix broken link

### DIFF
--- a/docs/proxy/friend_operator_equality.md
+++ b/docs/proxy/friend_operator_equality.md
@@ -35,4 +35,4 @@ int main() {
 
 ## See Also
 
-- [`has_value`](has_value.md)
+- [`has_value`](operator_bool.md)

--- a/docs/proxy/indirection.md
+++ b/docs/proxy/indirection.md
@@ -30,7 +30,7 @@ The behavior is undefined if `*this` does not contain a value.
 
 ## Notes
 
-These operators do not check whether the `proxy` contains a value. To check whether the `proxy` contains a value, call [`has_value()`](has_value.md) or use [operator ==](friend_operator_equality.md).
+These operators do not check whether the `proxy` contains a value. To check whether the `proxy` contains a value, call [`has_value()`](operator_bool.md) or use [operator ==](friend_operator_equality.md).
 
 ## Example
 


### PR DESCRIPTION
`proxy::has_value()` and `proxy::operator bool` share a [same page](https://microsoft.github.io/proxy/docs/proxy/operator_bool.html). Updated two broken links.