### PR TITLE
Reduce semantics of `proxy_invoke`

### DIFF
--- a/docs/PRO_DEF_FREE_DISPATCH.md
+++ b/docs/PRO_DEF_FREE_DISPATCH.md
@@ -36,7 +36,7 @@ struct dispatch_name {
   template <class F, class C, class R, class... Args>
   struct accessor<F, C, R(Args...) cv ref noex> {
     friend R accessibility_func_name(accessor cv ref self, Args... args) noex {
-      return pro::proxy_invoke<C>(pro::access_proxy<F>(SELF), std::forward<Args>(args)...);
+      return pro::proxy_invoke<C, R(Args...) cv ref noex>(pro::access_proxy<F>(SELF), std::forward<Args>(args)...);
     }
   };
 };

--- a/docs/PRO_DEF_MEM_DISPATCH.md
+++ b/docs/PRO_DEF_MEM_DISPATCH.md
@@ -39,7 +39,7 @@ struct dispatch_name {
   template <class F, class C, class R, class... Args>
   struct accessor<F, C, R(Args...) cv ref noex> {
     R accessibility_func_name(Args... args) cv ref noex {
-      return pro::proxy_invoke<C>(pro::access_proxy<F>(SELF), std::forward<Args>(args)...);
+      return pro::proxy_invoke<C, R(Args...) cv ref noex>(pro::access_proxy<F>(SELF), std::forward<Args>(args)...);
     }
   };
 };

--- a/docs/access_proxy.md
+++ b/docs/access_proxy.md
@@ -55,7 +55,7 @@ int main() {
   pro::proxy<Stringable>& p2 = pro::access_proxy<Stringable>(a);
   std::cout << std::boolalpha << (&p == &p2) << "\n";  // Prints: "true" because access_proxy converts
                                                        // an accessor back to the original proxy
-  auto result = pro::proxy_invoke<Convention>(p2);
+  auto result = pro::proxy_invoke<Convention, std::string()>(p2);
   std::cout << result << "\n";  // Prints: "123"
 }
 ```

--- a/docs/conversion_dispatch/accessor.md
+++ b/docs/conversion_dispatch/accessor.md
@@ -27,4 +27,4 @@ Let `SELF` be `std::forward<accessor cv ref>(*this)`.
 
 `(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, C, Os>...` are trivial types, inherits all `accessor<F, C, Os>...` types and `using` their `operator T`.
 
-`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an explicit (when `Expl` is `true`) or implicit (when `Expl` is `false`) `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<C>(access_proxy<F>(SELF))`.
+`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an explicit (when `Expl` is `true`) or implicit (when `Expl` is `false`) `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<C, T() cv ref noex>(access_proxy<F>(SELF))`.

--- a/docs/operator_dispatch/accessor.md
+++ b/docs/operator_dispatch/accessor.md
@@ -39,7 +39,7 @@ struct accessor<F, C, R(Args...) cv ref noex> {
 }
 ```
 
-`(3)` Provides an `operator sop(Args...)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Args...)` is equivalent to `return proxy_invoke<C>(access_proxy<F>(SELF), std::forward<Args>(args)...)`.
+`(3)` Provides an `operator sop(Args...)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Args...)` is equivalent to `return proxy_invoke<C, R(Args...) cv ref noex>(access_proxy<F>(SELF), std::forward<Args>(args)...)`.
 
 ### `!` and `~`
 
@@ -53,7 +53,7 @@ struct accessor<F, C, R() cv ref noex> {
 }
 ```
 
-`(4)` Provides an `operator sop()` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop()` is equivalent to `return proxy_invoke<C>(access_proxy<F>(SELF))`.
+`(4)` Provides an `operator sop()` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop()` is equivalent to `return proxy_invoke<C, R() cv ref noex>(access_proxy<F>(SELF))`.
 
 ### Assignment SOPs
 
@@ -67,7 +67,7 @@ struct accessor<F, C, R(Arg) cv ref noex> {
 }
 ```
 
-`(4)` Provides an `operator sop(Arg)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Arg)` calls `proxy_invoke<C>(access_proxy<F>(SELF), std::forward<Arg>(arg))` and returns `access_proxy<F>(SELF)` when `C::is_direct` is `true`, or otherwise, returns `*access_proxy<F>(SELF)` when `C::is_direct` is `false`.
+`(4)` Provides an `operator sop(Arg)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Arg)` calls `proxy_invoke<C, R(Arg) cv ref noex>(access_proxy<F>(SELF), std::forward<Arg>(arg))` and returns `access_proxy<F>(SELF)` when `C::is_direct` is `true`, or otherwise, returns `*access_proxy<F>(SELF)` when `C::is_direct` is `false`.
 
 ## Right-Hand-Side Operand Specializations
 
@@ -94,7 +94,7 @@ struct accessor<F, C, R(Arg) cv ref noex> {
 }
 ```
 
-`(7)` Provides a `friend operator sop(Arg arg, accessor cv ref)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor cv ref)` is equivalent to `return proxy_invoke<C>(access_proxy<F>(SELF), std::forward<Arg>(arg))`.
+`(7)` Provides a `friend operator sop(Arg arg, accessor cv ref)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor cv ref)` is equivalent to `return proxy_invoke<C, R(Arg) cv ref noex>(access_proxy<F>(SELF), std::forward<Arg>(arg))`.
 
 ### Assignment SOPs
 
@@ -108,4 +108,4 @@ struct accessor<F, C, R(Arg) cv ref noex> {
 }
 ```
 
-`(8)` Provides a `friend operator sop(Arg arg, accessor cv ref)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor cv ref)` calls `proxy_invoke<C>(access_proxy<F>(SELF), std::forward<Arg>(arg))` and returns `access_proxy<F>(SELF)` when `C::is_direct` is `true`, or otherwise, returns `*access_proxy<F>(SELF)` when `C::is_direct` is `false`.
+`(8)` Provides a `friend operator sop(Arg arg, accessor cv ref)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor cv ref)` calls `proxy_invoke<C, R(Arg) cv ref noex>(access_proxy<F>(SELF), std::forward<Arg>(arg))` and returns `access_proxy<F>(SELF)` when `C::is_direct` is `true`, or otherwise, returns `*access_proxy<F>(SELF)` when `C::is_direct` is `false`.

--- a/docs/proxy_invoke.md
+++ b/docs/proxy_invoke.md
@@ -1,22 +1,22 @@
 # Function template `proxy_invoke`
 
 ```cpp
-template <class C, class F, class... Args>
+template <class C, class O, class F, class... Args>
 /* see below */ proxy_invoke(proxy<F>& p, Args&&... args);
 
-template <class C, class F, class... Args>
+template <class C, class O, class F, class... Args>
 /* see below */ proxy_invoke(const proxy<F>& p, Args&&... args);
 
-template <class C, class F, class... Args>
+template <class C, class O, class F, class... Args>
 /* see below */ proxy_invoke(proxy<F>&& p, Args&&... args);
 
-template <class C, class F, class... Args>
+template <class C, class O, class F, class... Args>
 /* see below */ proxy_invoke(const proxy<F>&& p, Args&&... args);
 ```
 
-Invokes a `proxy` with a specified convention type and arguments. `C` is required to be defined in `typename F::convention_types`. Overload resolution is performed among the overload types defined in `typename C::overload_types`.
+Invokes a `proxy` with a specified convention type, an overload type, and arguments. `C` is required to be defined in `typename F::convention_types`. `O` is required to be defined in `typename C::overload_types`.
 
-Let `ptr` be the contained value of `p` with the same cv ref-qualifiers, `O` be the matched overload type among the overload types defined in `typename C::overload_types`, `Args2...` be the argument types of `O`, `R` be the return type of `O`,
+Let `ptr` be the contained value of `p` with the same cv ref-qualifiers, `Args2...` be the argument types of `O`, `R` be the return type of `O`,
 
 - if `C::is_direct` is `true`, let `v` be `std::forward<decltype(ptr)>(ptr)`, or otherwise,
 - if `C::is_direct` is `false`, let `v` be `*std::forward<decltype(ptr)>(ptr)`,
@@ -55,7 +55,7 @@ int main() {
   std::cout << ToString(*p) << "\n";  // Invokes with accessor, prints: "123"
 
   using C = std::tuple_element_t<0u, Stringable::convention_types>;
-  std::cout << pro::proxy_invoke<C>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
+  std::cout << pro::proxy_invoke<C, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
 }
 ```
 

--- a/samples/access_proxy.cpp
+++ b/samples/access_proxy.cpp
@@ -27,6 +27,6 @@ int main() {
   pro::proxy<Stringable>& p2 = pro::access_proxy<Stringable>(a);
   std::cout << std::boolalpha << (&p == &p2) << "\n";  // Prints: "true" because access_proxy converts
                                                        // an accessor back to the original proxy
-  auto result = pro::proxy_invoke<Convention>(p2);
+  auto result = pro::proxy_invoke<Convention, std::string()>(p2);
   std::cout << result << "\n";  // Prints: "123"
 }

--- a/samples/msft_lib_proxy.cpp
+++ b/samples/msft_lib_proxy.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-// This file contains example code from __msft_lib_proxy.md.
+// This file contains example code from msft_lib_proxy.md.
 
 #include <cstdio>
 

--- a/samples/proxy_invoke.cpp
+++ b/samples/proxy_invoke.cpp
@@ -19,5 +19,5 @@ int main() {
   std::cout << ToString(*p) << "\n";  // Invokes with accessor, prints: "123"
 
   using C = std::tuple_element_t<0u, Stringable::convention_types>;
-  std::cout << pro::proxy_invoke<C>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
+  std::cout << pro::proxy_invoke<C, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
 }


### PR DESCRIPTION
**Why**

Before this change, each polymorphic call performed with `proxy` accessibility API will cause overload resolution twice. Although it does not affect code generation, it introduces unnecessary compile-time dependency.

**Changes**

- Added overload type `O` to each overload of `proxy_invoke`.
- Updated implementation of the dispatch types accordingly.
- Updated documentation and sample code accordingly.

**Notes**

- Since this change involves API change, the minor version of the library should be updated later.