### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -20,6 +20,10 @@ jobs:
 
     - name: build and run test with AppleClang
       run: |
-        cmake -B build
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build -j
         ctest --test-dir build -j
+
+    - name: run benchmarks
+      run: |
+        ./build/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -26,24 +26,31 @@ jobs:
 
     - name: build and run test with clang 15
       run: |
-        cmake -B build-clang-15 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15
+        cmake -B build-clang-15 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-clang-15 -j
         ctest --test-dir build-clang-15 -j
 
     - name: build and run test with clang 16
       run: |
-        cmake -B build-clang-16 -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16
+        cmake -B build-clang-16 -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-clang-16 -j
         ctest --test-dir build-clang-16 -j
 
     - name: build and run test with clang 17
       run: |
-        cmake -B build-clang-17 -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17
+        cmake -B build-clang-17 -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-clang-17 -j
         ctest --test-dir build-clang-17 -j
 
     - name: build and run test with clang 18
       run: |
-        cmake -B build-clang-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18
+        cmake -B build-clang-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-clang-18 -j
         ctest --test-dir build-clang-18 -j
+
+    - name: run benchmarks
+      run: |
+        ./build-clang-15/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-clang-16/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-clang-17/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-clang-18/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -50,7 +50,4 @@ jobs:
 
     - name: run benchmarks
       run: |
-        ./build-clang-15/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
-        ./build-clang-16/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
-        ./build-clang-17/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
         ./build-clang-18/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -50,7 +50,4 @@ jobs:
 
     - name: run benchmarks
       run: |
-        ./build-gcc-11/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
-        ./build-gcc-12/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
-        ./build-gcc-13/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
         ./build-gcc-14/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -26,24 +26,31 @@ jobs:
 
     - name: build and run test with gcc 11
       run: |
-        cmake -B build-gcc-11 -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+        cmake -B build-gcc-11 -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-gcc-11 -j
         ctest --test-dir build-gcc-11 -j
 
     - name: build and run test with gcc 12
       run: |
-        cmake -B build-gcc-12 -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
+        cmake -B build-gcc-12 -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-gcc-12 -j
         ctest --test-dir build-gcc-12 -j
 
     - name: build and run test with gcc 13
       run: |
-        cmake -B build-gcc-13 -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
+        cmake -B build-gcc-13 -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-gcc-13 -j
         ctest --test-dir build-gcc-13 -j
 
     - name: build and run test with gcc 14
       run: |
-        cmake -B build-gcc-14 -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14
+        cmake -B build-gcc-14 -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_BUILD_TYPE=Release
         cmake --build build-gcc-14 -j
         ctest --test-dir build-gcc-14 -j
+
+    - name: run benchmarks
+      run: |
+        ./build-gcc-11/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-gcc-12/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-gcc-13/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
+        ./build-gcc-14/benchmarks/msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/.github/workflows/bvt-msvc.yml
+++ b/.github/workflows/bvt-msvc.yml
@@ -13,11 +13,12 @@ jobs:
       with:
         ref: ${{ inputs.branch }}
 
-    - name: build with cmake
+    - name: build and run test with MSVC
       run: |
         cmake -B build
-        cmake --build build -j
-
-    - name: run tests
-      run: |
+        cmake --build build --config Release -j
         ctest --test-dir build -j
+
+    - name: run benchmarks
+      run: |
+        .\build\benchmarks\Release\msft_proxy_benchmarks.exe --benchmark_repetitions=10 --benchmark_report_aggregates_only=true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,21 +26,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/proxyConfigVersion.cmake
 # build tests if BUILD_TESTING is ON
 include(CTest)
 if (BUILD_TESTING)
-  include(FetchContent)
-  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
-  # allows for proper rebuilds when a projects URL changes.
-  if(POLICY CMP0135)
-    cmake_policy(SET CMP0135 NEW)
-  endif()
-  FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
-  )
-
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings
-  set(BUILD_GMOCK OFF CACHE BOOL "" FORCE) # Disable GMock
-  FetchContent_MakeAvailable(googletest)
-
   add_subdirectory(tests)
+  add_subdirectory(benchmarks)
   add_subdirectory(samples)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,31 @@
+project(msft_proxy_benchmarks)
+
+include(FetchContent)
+# The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+# allows for proper rebuilds when a projects URL changes.
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
+FetchContent_Declare(
+  benchmark
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.0.tar.gz
+  URL_HASH SHA256=35a77f46cc782b16fac8d3b107fbfbb37dcd645f7c28eee19f3b8e0758b48994
+)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable tests for google benchmark")
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Disable google benchmark unit tests")
+FetchContent_MakeAvailable(benchmark)
+
+add_executable(msft_proxy_benchmarks
+  proxy_invocation_benchmark_context.cpp
+  proxy_invocation_benchmark.cpp
+  proxy_management_benchmark.cpp
+)
+target_include_directories(msft_proxy_benchmarks PRIVATE .)
+target_link_libraries(msft_proxy_benchmarks PRIVATE msft_proxy benchmark::benchmark benchmark::benchmark_main)
+
+if (MSVC)
+  target_compile_options(msft_proxy_benchmarks PRIVATE /W4)
+else()
+  target_compile_options(msft_proxy_benchmarks PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -40,9 +40,8 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
     }
   }
 }
-/*
+
 BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
-*/

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <benchmark/benchmark.h>
+
+#include "proxy_invocation_benchmark_context.h"
+
+void BM_SmallObjectInvocationViaProxy(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : SmallObjectInvocationProxyTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
+void BM_SmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : SmallObjectInvocationVirtualFunctionTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
+void BM_LargeObjectInvocationViaProxy(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : LargeObjectInvocationProxyTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
+void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : LargeObjectInvocationVirtualFunctionTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
+BENCHMARK(BM_SmallObjectInvocationViaProxy);
+BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
+BENCHMARK(BM_LargeObjectInvocationViaProxy);
+BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -40,8 +40,9 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
     }
   }
 }
-
+/*
 BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
+*/

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -41,7 +41,27 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
   }
 }
 
+void BM_PooledObjectInvocationViaProxy(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : PooledObjectInvocationProxyTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
+void BM_PooledObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : PooledObjectInvocationVirtualFunctionTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
 BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
+BENCHMARK(BM_PooledObjectInvocationViaProxy);
+BENCHMARK(BM_PooledObjectInvocationViaVirtualFunction);

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -23,6 +23,15 @@ void BM_SmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
   }
 }
 
+void BM_PooledSmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto& p : PooledSmallObjectInvocationVirtualFunctionTestData) {
+      int result = p->Fun();
+      benchmark::DoNotOptimize(result);
+    }
+  }
+}
+
 void BM_LargeObjectInvocationViaProxy(benchmark::State& state) {
   for (auto _ : state) {
     for (auto& p : LargeObjectInvocationProxyTestData) {
@@ -41,18 +50,18 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
   }
 }
 
-void BM_PooledObjectInvocationViaProxy(benchmark::State& state) {
+void BM_PooledLargeObjectInvocationViaProxy(benchmark::State& state) {
   for (auto _ : state) {
-    for (auto& p : PooledObjectInvocationProxyTestData) {
+    for (auto& p : PooledLargeObjectInvocationProxyTestData) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
   }
 }
 
-void BM_PooledObjectInvocationViaVirtualFunction(benchmark::State& state) {
+void BM_PooledLargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
   for (auto _ : state) {
-    for (auto& p : PooledObjectInvocationVirtualFunctionTestData) {
+    for (auto& p : PooledLargeObjectInvocationVirtualFunctionTestData) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
@@ -61,7 +70,8 @@ void BM_PooledObjectInvocationViaVirtualFunction(benchmark::State& state) {
 
 BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
+BENCHMARK(BM_PooledSmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
-BENCHMARK(BM_PooledObjectInvocationViaProxy);
-BENCHMARK(BM_PooledObjectInvocationViaVirtualFunction);
+BENCHMARK(BM_PooledLargeObjectInvocationViaProxy);
+BENCHMARK(BM_PooledLargeObjectInvocationViaVirtualFunction);

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -23,15 +23,6 @@ void BM_SmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
   }
 }
 
-void BM_PooledSmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
-  for (auto _ : state) {
-    for (auto& p : PooledSmallObjectInvocationVirtualFunctionTestData) {
-      int result = p->Fun();
-      benchmark::DoNotOptimize(result);
-    }
-  }
-}
-
 void BM_LargeObjectInvocationViaProxy(benchmark::State& state) {
   for (auto _ : state) {
     for (auto& p : LargeObjectInvocationProxyTestData) {
@@ -50,28 +41,7 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
   }
 }
 
-void BM_PooledLargeObjectInvocationViaProxy(benchmark::State& state) {
-  for (auto _ : state) {
-    for (auto& p : PooledLargeObjectInvocationProxyTestData) {
-      int result = p->Fun();
-      benchmark::DoNotOptimize(result);
-    }
-  }
-}
-
-void BM_PooledLargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
-  for (auto _ : state) {
-    for (auto& p : PooledLargeObjectInvocationVirtualFunctionTestData) {
-      int result = p->Fun();
-      benchmark::DoNotOptimize(result);
-    }
-  }
-}
-
 BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
-BENCHMARK(BM_PooledSmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
-BENCHMARK(BM_PooledLargeObjectInvocationViaProxy);
-BENCHMARK(BM_PooledLargeObjectInvocationViaVirtualFunction);

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -90,6 +90,12 @@ const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirt
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return std::unique_ptr<InvocationTestBase>{new IntrusiveSmallImpl<TypeSeries>(seed)}; });
 
+const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledSmallObjectInvocationVirtualFunctionTestData = GenerateTestData(
+    []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
+      return std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>{
+          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveSmallImpl<TypeSeries>>(seed)};
+    });
+
 const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return pro::make_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(seed); });
@@ -98,13 +104,13 @@ const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirt
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return std::unique_ptr<InvocationTestBase>{new IntrusiveLargeImpl<TypeSeries>(seed)}; });
 
-const std::vector<pro::proxy<InvocationTestFacade>> PooledObjectInvocationProxyTestData = GenerateTestData(
+const std::vector<pro::proxy<InvocationTestFacade>> PooledLargeObjectInvocationProxyTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
       return pro::allocate_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(
           std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}, seed);
     });
 
-const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledObjectInvocationVirtualFunctionTestData = GenerateTestData(
+const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledLargeObjectInvocationVirtualFunctionTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
       return std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>{
           std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveLargeImpl<TypeSeries>>(seed)};

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -101,11 +101,11 @@ const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirt
 const std::vector<pro::proxy<InvocationTestFacade>> PooledObjectInvocationProxyTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
       return pro::allocate_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(
-          std::pmr::polymorphic_allocator{&details::InvocationBenchmarkMemoryPool}, seed);
+          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}, seed);
     });
 
 const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledObjectInvocationVirtualFunctionTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
       return std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>{
-          std::pmr::polymorphic_allocator{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveLargeImpl<TypeSeries>>(seed)};
+          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveLargeImpl<TypeSeries>>(seed)};
     });

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -76,12 +76,6 @@ auto GenerateTestData(const F& generator) {
 
 }  // namespace
 
-namespace details {
-
-std::pmr::unsynchronized_pool_resource InvocationBenchmarkMemoryPool;
-
-}  // namespace details
-
 const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return pro::make_proxy<InvocationTestFacade, NonIntrusiveSmallImpl<TypeSeries>>(seed); });
@@ -90,12 +84,6 @@ const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirt
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return std::unique_ptr<InvocationTestBase>{new IntrusiveSmallImpl<TypeSeries>(seed)}; });
 
-const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledSmallObjectInvocationVirtualFunctionTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
-      return std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>{
-          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveSmallImpl<TypeSeries>>(seed)};
-    });
-
 const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return pro::make_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(seed); });
@@ -103,15 +91,3 @@ const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTe
 const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData = GenerateTestData(
     []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
         { return std::unique_ptr<InvocationTestBase>{new IntrusiveLargeImpl<TypeSeries>(seed)}; });
-
-const std::vector<pro::proxy<InvocationTestFacade>> PooledLargeObjectInvocationProxyTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
-      return pro::allocate_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(
-          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}, seed);
-    });
-
-const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledLargeObjectInvocationVirtualFunctionTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed) {
-      return std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>{
-          std::pmr::polymorphic_allocator<>{&details::InvocationBenchmarkMemoryPool}.new_object<IntrusiveLargeImpl<TypeSeries>>(seed)};
-    });

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "proxy_invocation_benchmark_context.h"
+
+namespace {
+
+constexpr int TestDataSize = 1000000;
+constexpr int TypeSeriesCount = 100;
+
+template <int TypeSeries>
+class NonIntrusiveSmallImpl {
+ public:
+  explicit NonIntrusiveSmallImpl(int seed) noexcept : seed_(seed) {}
+  NonIntrusiveSmallImpl(const NonIntrusiveSmallImpl&) noexcept = default;
+  int Fun() const noexcept { return seed_ ^ (TypeSeries + 1); }
+
+ private:
+  int seed_;
+};
+
+template <int TypeSeries>
+class NonIntrusiveLargeImpl {
+ public:
+  explicit NonIntrusiveLargeImpl(int seed) noexcept : seed_(seed) {}
+  NonIntrusiveLargeImpl(const NonIntrusiveLargeImpl&) noexcept = default;
+  int Fun() const noexcept { return seed_ ^ (TypeSeries + 1); }
+
+ private:
+  void* padding_[16]{};
+  int seed_;
+};
+
+template <int TypeSeries>
+class IntrusiveSmallImpl : public InvocationTestBase {
+ public:
+  explicit IntrusiveSmallImpl(int seed) noexcept : seed_(seed) {}
+  IntrusiveSmallImpl(const IntrusiveSmallImpl&) noexcept = default;
+  int Fun() const noexcept override { return seed_ ^ (TypeSeries + 1); }
+
+ private:
+  int seed_;
+};
+
+template <int TypeSeries>
+class IntrusiveLargeImpl : public InvocationTestBase {
+ public:
+  explicit IntrusiveLargeImpl(int seed) noexcept : seed_(seed) {}
+  IntrusiveLargeImpl(const IntrusiveLargeImpl&) noexcept = default;
+  int Fun() const noexcept override { return seed_ ^ (TypeSeries + 1); }
+
+ private:
+  void* padding_[16]{};
+  int seed_;
+};
+
+template <template <int> class T, int FromTypeSeries>
+void FillProxyTestData(std::vector<pro::proxy<InvocationTestFacade>>& data) {
+  if constexpr (FromTypeSeries < TypeSeriesCount) {
+    for (int i = FromTypeSeries; i < TestDataSize; i += TypeSeriesCount) {
+      data[i] = pro::make_proxy<InvocationTestFacade, T<FromTypeSeries>>(static_cast<int>(i));
+    }
+    FillProxyTestData<T, FromTypeSeries + 1>(data);
+  }
+}
+
+template <template <int> class T>
+std::vector<pro::proxy<InvocationTestFacade>> GenerateProxyTestData() {
+  std::vector<pro::proxy<InvocationTestFacade>> result(TestDataSize);
+  FillProxyTestData<T, 0>(result);
+  return result;
+}
+
+template <template <int> class T, int FromTypeSeries>
+void FillVirtualFunctionTestData(std::vector<std::unique_ptr<InvocationTestBase>>& data) {
+  if constexpr (FromTypeSeries < TypeSeriesCount) {
+    for (int i = FromTypeSeries; i < TestDataSize; i += TypeSeriesCount) {
+      data[i].reset(new T<FromTypeSeries>(static_cast<int>(i)));
+    }
+    FillVirtualFunctionTestData<T, FromTypeSeries + 1>(data);
+  }
+}
+
+template <template <int> class T>
+std::vector<std::unique_ptr<InvocationTestBase>> GenerateVirtualFunctionTestData() {
+  std::vector<std::unique_ptr<InvocationTestBase>> result(TestDataSize);
+  FillVirtualFunctionTestData<T, 0>(result);
+  return result;
+}
+
+}  // namespace
+
+const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData = GenerateProxyTestData<NonIntrusiveSmallImpl>();
+const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData = GenerateVirtualFunctionTestData<IntrusiveSmallImpl>();
+const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData = GenerateProxyTestData<NonIntrusiveLargeImpl>();
+const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData = GenerateVirtualFunctionTestData<IntrusiveLargeImpl>();

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -2,9 +2,23 @@
 // Licensed under the MIT License.
 
 #include <memory>
+#include <memory_resource>
 #include <vector>
 
 #include "proxy.h"
+
+namespace details {
+
+extern std::pmr::unsynchronized_pool_resource InvocationBenchmarkMemoryPool;
+
+struct InvocationBenchmarkPolledDeleter {
+  void operator()(auto* ptr) const noexcept {
+    std::pmr::polymorphic_allocator<> alloc{&InvocationBenchmarkMemoryPool};
+    alloc.delete_object(ptr);
+  }
+};
+
+}  // namespace details
 
 PRO_DEF_MEM_DISPATCH(MemFun, Fun);
 
@@ -21,3 +35,5 @@ extern const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocation
 extern const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData;
 extern const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData;
 extern const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData;
+extern const std::vector<pro::proxy<InvocationTestFacade>> PooledObjectInvocationProxyTestData;
+extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledObjectInvocationVirtualFunctionTestData;

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -2,23 +2,9 @@
 // Licensed under the MIT License.
 
 #include <memory>
-#include <memory_resource>
 #include <vector>
 
 #include "proxy.h"
-
-namespace details {
-
-extern std::pmr::unsynchronized_pool_resource InvocationBenchmarkMemoryPool;
-
-struct InvocationBenchmarkPolledDeleter {
-  void operator()(auto* ptr) const noexcept {
-    std::pmr::polymorphic_allocator<> alloc{&InvocationBenchmarkMemoryPool};
-    alloc.delete_object(ptr);
-  }
-};
-
-}  // namespace details
 
 PRO_DEF_MEM_DISPATCH(MemFun, Fun);
 
@@ -33,8 +19,5 @@ struct InvocationTestBase {
 
 extern const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData;
 extern const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData;
-extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledSmallObjectInvocationVirtualFunctionTestData;
 extern const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData;
 extern const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData;
-extern const std::vector<pro::proxy<InvocationTestFacade>> PooledLargeObjectInvocationProxyTestData;
-extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledLargeObjectInvocationVirtualFunctionTestData;

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -33,7 +33,8 @@ struct InvocationTestBase {
 
 extern const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData;
 extern const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData;
+extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledSmallObjectInvocationVirtualFunctionTestData;
 extern const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData;
 extern const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData;
-extern const std::vector<pro::proxy<InvocationTestFacade>> PooledObjectInvocationProxyTestData;
-extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledObjectInvocationVirtualFunctionTestData;
+extern const std::vector<pro::proxy<InvocationTestFacade>> PooledLargeObjectInvocationProxyTestData;
+extern const std::vector<std::unique_ptr<InvocationTestBase, details::InvocationBenchmarkPolledDeleter>> PooledLargeObjectInvocationVirtualFunctionTestData;

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <memory>
+#include <vector>
+
+#include "proxy.h"
+
+PRO_DEF_MEM_DISPATCH(MemFun, Fun);
+
+struct InvocationTestFacade : pro::facade_builder
+    ::add_convention<MemFun, int() const>
+    ::build{};
+
+struct InvocationTestBase {
+  virtual int Fun() const = 0;
+  virtual ~InvocationTestBase() = default;
+};
+
+extern const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData;
+extern const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData;
+extern const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData;
+extern const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData;

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -52,18 +52,11 @@ void BM_SmallObjectManagementWithProxy(benchmark::State& state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      auto p1 = pro::make_proxy<DefaultFacade, SmallObject1>();
-      auto p2 = pro::make_proxy<DefaultFacade, SmallObject2>();
-      auto p3 = pro::make_proxy<DefaultFacade, SmallObject3>();
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.push_back(pro::make_proxy<DefaultFacade, SmallObject1>());
+      data.push_back(pro::make_proxy<DefaultFacade, SmallObject2>());
+      data.push_back(pro::make_proxy<DefaultFacade, SmallObject3>());
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -72,18 +65,11 @@ void BM_SmallObjectManagementWithUniquePtr(benchmark::State& state) {
     std::vector<std::unique_ptr<PolymorphicObjectBase>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::unique_ptr<PolymorphicObjectBase> p1{new PolymorphicObject<SmallObject1>()};
-      std::unique_ptr<PolymorphicObjectBase> p2{new PolymorphicObject<SmallObject2>()};
-      std::unique_ptr<PolymorphicObjectBase> p3{new PolymorphicObject<SmallObject3>()};
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<SmallObject1>()});
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<SmallObject2>()});
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<SmallObject3>()});
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -92,18 +78,11 @@ void BM_SmallObjectManagementWithSharedPtr(benchmark::State& state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::make_shared<SmallObject1>();
-      std::shared_ptr<void> p2 = std::make_shared<SmallObject2>();
-      std::shared_ptr<void> p3 = std::make_shared<SmallObject3>();
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.emplace_back(std::make_shared<SmallObject1>());
+      data.emplace_back(std::make_shared<SmallObject2>());
+      data.emplace_back(std::make_shared<SmallObject3>());
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -114,18 +93,11 @@ void BM_SmallObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::allocate_shared<SmallObject1>(alloc);
-      std::shared_ptr<void> p2 = std::allocate_shared<SmallObject2>(alloc);
-      std::shared_ptr<void> p3 = std::allocate_shared<SmallObject3>(alloc);
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.emplace_back(std::allocate_shared<SmallObject1>(alloc));
+      data.emplace_back(std::allocate_shared<SmallObject2>(alloc));
+      data.emplace_back(std::allocate_shared<SmallObject3>(alloc));
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -134,18 +106,11 @@ void BM_SmallObjectManagementWithAny(benchmark::State& state) {
     std::vector<std::any> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::any a1 = SmallObject1{};
-      std::any a2 = SmallObject2{};
-      std::any a3 = SmallObject3{};
-
-      benchmark::DoNotOptimize(a1);
-      benchmark::DoNotOptimize(a2);
-      benchmark::DoNotOptimize(a3);
-
-      data.push_back(std::move(a1));
-      data.push_back(std::move(a2));
-      data.push_back(std::move(a3));
+      data.emplace_back(SmallObject1{});
+      data.emplace_back(SmallObject2{});
+      data.emplace_back(SmallObject3{});
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -154,18 +119,11 @@ void BM_LargeObjectManagementWithProxy(benchmark::State& state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      auto p1 = pro::make_proxy<DefaultFacade, LargeObject1>();
-      auto p2 = pro::make_proxy<DefaultFacade, LargeObject2>();
-      auto p3 = pro::make_proxy<DefaultFacade, LargeObject3>();
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.push_back(pro::make_proxy<DefaultFacade, LargeObject1>());
+      data.push_back(pro::make_proxy<DefaultFacade, LargeObject2>());
+      data.push_back(pro::make_proxy<DefaultFacade, LargeObject3>());
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -176,18 +134,11 @@ void BM_LargeObjectManagementWithProxy_Pooled(benchmark::State& state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      auto p1 = pro::allocate_proxy<DefaultFacade, LargeObject1>(alloc);
-      auto p2 = pro::allocate_proxy<DefaultFacade, LargeObject2>(alloc);
-      auto p3 = pro::allocate_proxy<DefaultFacade, LargeObject3>(alloc);
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.push_back(pro::allocate_proxy<DefaultFacade, LargeObject1>(alloc));
+      data.push_back(pro::allocate_proxy<DefaultFacade, LargeObject2>(alloc));
+      data.push_back(pro::allocate_proxy<DefaultFacade, LargeObject3>(alloc));
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -196,18 +147,11 @@ void BM_LargeObjectManagementWithUniquePtr(benchmark::State& state) {
     std::vector<std::unique_ptr<PolymorphicObjectBase>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::unique_ptr<PolymorphicObjectBase> p1{new PolymorphicObject<LargeObject1>()};
-      std::unique_ptr<PolymorphicObjectBase> p2{new PolymorphicObject<LargeObject2>()};
-      std::unique_ptr<PolymorphicObjectBase> p3{new PolymorphicObject<LargeObject3>()};
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<LargeObject1>()});
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<LargeObject2>()});
+      data.push_back(std::unique_ptr<PolymorphicObjectBase>{new PolymorphicObject<LargeObject3>()});
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -216,44 +160,26 @@ void BM_LargeObjectManagementWithSharedPtr(benchmark::State& state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::make_shared<LargeObject1>();
-      std::shared_ptr<void> p2 = std::make_shared<LargeObject2>();
-      std::shared_ptr<void> p3 = std::make_shared<LargeObject3>();
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.emplace_back(std::make_shared<LargeObject1>());
+      data.emplace_back(std::make_shared<LargeObject2>());
+      data.emplace_back(std::make_shared<LargeObject3>());
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
 void BM_LargeObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
-  std::pmr::unsynchronized_pool_resource pool1{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject1)}};
-  std::pmr::unsynchronized_pool_resource pool2{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject2)}};
-  std::pmr::unsynchronized_pool_resource pool3{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject3)}};
-  std::pmr::polymorphic_allocator<> alloc1{&pool1};
-  std::pmr::polymorphic_allocator<> alloc2{&pool2};
-  std::pmr::polymorphic_allocator<> alloc3{&pool3};
+  std::pmr::unsynchronized_pool_resource pool;
+  std::pmr::polymorphic_allocator<> alloc{&pool};
   for (auto _ : state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::allocate_shared<LargeObject1>(alloc1);
-      std::shared_ptr<void> p2 = std::allocate_shared<LargeObject2>(alloc2);
-      std::shared_ptr<void> p3 = std::allocate_shared<LargeObject3>(alloc3);
-
-      benchmark::DoNotOptimize(p1);
-      benchmark::DoNotOptimize(p2);
-      benchmark::DoNotOptimize(p3);
-
-      data.push_back(std::move(p1));
-      data.push_back(std::move(p2));
-      data.push_back(std::move(p3));
+      data.emplace_back(std::allocate_shared<LargeObject1>(alloc));
+      data.emplace_back(std::allocate_shared<LargeObject2>(alloc));
+      data.emplace_back(std::allocate_shared<LargeObject3>(alloc));
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 
@@ -262,18 +188,11 @@ void BM_LargeObjectManagementWithAny(benchmark::State& state) {
     std::vector<std::any> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::any a1 = LargeObject1{};
-      std::any a2 = LargeObject2{};
-      std::any a3 = LargeObject3{};
-
-      benchmark::DoNotOptimize(a1);
-      benchmark::DoNotOptimize(a2);
-      benchmark::DoNotOptimize(a3);
-
-      data.push_back(std::move(a1));
-      data.push_back(std::move(a2));
-      data.push_back(std::move(a3));
+      data.emplace_back(LargeObject1{});
+      data.emplace_back(LargeObject2{});
+      data.emplace_back(LargeObject3{});
     }
+    benchmark::DoNotOptimize(data);
   }
 }
 

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -33,11 +33,6 @@ struct LargeObject3 {
   void* Padding[15];
 };
 
-template <class T>
-std::pmr::unsynchronized_pool_resource CreateMemoryPool() {
-  return std::pmr::unsynchronized_pool_resource{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(T)}};
-}
-
 }  // namespace
 
 struct DefaultFacade : pro::facade_builder
@@ -85,16 +80,15 @@ void BM_SmallObjectManagementWithSharedPtr(benchmark::State& state) {
 }
 
 void BM_SmallObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
-  auto pool1 = CreateMemoryPool<SmallObject1>();
-  auto pool2 = CreateMemoryPool<SmallObject2>();
-  auto pool3 = CreateMemoryPool<SmallObject3>();
+  std::pmr::unsynchronized_pool_resource pool;
+  std::pmr::polymorphic_allocator<> alloc{&pool};
   for (auto _ : state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::allocate_shared<SmallObject1>(std::pmr::polymorphic_allocator<>{&pool1});
-      std::shared_ptr<void> p2 = std::allocate_shared<SmallObject2>(std::pmr::polymorphic_allocator<>{&pool2});
-      std::shared_ptr<void> p3 = std::allocate_shared<SmallObject3>(std::pmr::polymorphic_allocator<>{&pool3});
+      std::shared_ptr<void> p1 = std::allocate_shared<SmallObject1>(alloc);
+      std::shared_ptr<void> p2 = std::allocate_shared<SmallObject2>(alloc);
+      std::shared_ptr<void> p3 = std::allocate_shared<SmallObject3>(alloc);
 
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);
@@ -148,16 +142,15 @@ void BM_LargeObjectManagementWithProxy(benchmark::State& state) {
 }
 
 void BM_LargeObjectManagementWithProxy_Pooled(benchmark::State& state) {
-  auto pool1 = CreateMemoryPool<LargeObject1>();
-  auto pool2 = CreateMemoryPool<LargeObject2>();
-  auto pool3 = CreateMemoryPool<LargeObject3>();
+  std::pmr::unsynchronized_pool_resource pool;
+  std::pmr::polymorphic_allocator<> alloc{&pool};
   for (auto _ : state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      auto p1 = pro::allocate_proxy<DefaultFacade, LargeObject1>(std::pmr::polymorphic_allocator<>{&pool1});
-      auto p2 = pro::allocate_proxy<DefaultFacade, LargeObject2>(std::pmr::polymorphic_allocator<>{&pool2});
-      auto p3 = pro::allocate_proxy<DefaultFacade, LargeObject3>(std::pmr::polymorphic_allocator<>{&pool3});
+      auto p1 = pro::allocate_proxy<DefaultFacade, LargeObject1>(alloc);
+      auto p2 = pro::allocate_proxy<DefaultFacade, LargeObject2>(alloc);
+      auto p3 = pro::allocate_proxy<DefaultFacade, LargeObject3>(alloc);
 
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);
@@ -191,16 +184,19 @@ void BM_LargeObjectManagementWithSharedPtr(benchmark::State& state) {
 }
 
 void BM_LargeObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
-  auto pool1 = CreateMemoryPool<LargeObject1>();
-  auto pool2 = CreateMemoryPool<LargeObject2>();
-  auto pool3 = CreateMemoryPool<LargeObject3>();
+  std::pmr::unsynchronized_pool_resource pool1{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject1)}};
+  std::pmr::unsynchronized_pool_resource pool2{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject2)}};
+  std::pmr::unsynchronized_pool_resource pool3{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject3)}};
+  std::pmr::polymorphic_allocator<> alloc1{&pool1};
+  std::pmr::polymorphic_allocator<> alloc2{&pool2};
+  std::pmr::polymorphic_allocator<> alloc3{&pool3};
   for (auto _ : state) {
     std::vector<std::shared_ptr<void>> data;
     data.reserve(TestManagedObjectCount);
     for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
-      std::shared_ptr<void> p1 = std::allocate_shared<LargeObject1>(std::pmr::polymorphic_allocator<>{&pool1});
-      std::shared_ptr<void> p2 = std::allocate_shared<LargeObject2>(std::pmr::polymorphic_allocator<>{&pool2});
-      std::shared_ptr<void> p3 = std::allocate_shared<LargeObject3>(std::pmr::polymorphic_allocator<>{&pool3});
+      std::shared_ptr<void> p1 = std::allocate_shared<LargeObject1>(alloc1);
+      std::shared_ptr<void> p2 = std::allocate_shared<LargeObject2>(alloc2);
+      std::shared_ptr<void> p3 = std::allocate_shared<LargeObject3>(alloc3);
 
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-constexpr int TestManagedObjectCount = 12000;
+constexpr int TestManagedObjectCount = 120000;
 constexpr int TypeSeriesCount = 3;
 
 using SmallObject1 = int;

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <any>
+#include <array>
+#include <forward_list>
+#include <string>
+
+#include <benchmark/benchmark.h>
+
+#include "proxy.h"
+
+namespace {
+
+constexpr int TestManagedObjectCount = 12000;
+
+}  // namespace
+
+struct DefaultFacade : pro::facade_builder
+    ::support_copy<pro::constraint_level::nontrivial>
+    ::build {};
+
+void BM_SmallObjectManagementWithProxy(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<pro::proxy<DefaultFacade>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += 3) {
+      auto p0 = pro::make_proxy<DefaultFacade>(123);
+      auto p1 = pro::make_proxy<DefaultFacade, std::shared_ptr<int>>();
+      auto p2 = pro::make_proxy<DefaultFacade, std::forward_list<double>>();
+
+      benchmark::DoNotOptimize(p0);
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+
+      data.push_back(std::move(p0));
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+    }
+  }
+}
+
+void BM_SmallObjectManagementWithAny(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<std::any> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += 3) {
+      std::any a0 = 123;
+      std::any a1 = std::shared_ptr<int>{};
+      std::any a2 = std::forward_list<double>{};
+
+      benchmark::DoNotOptimize(a0);
+      benchmark::DoNotOptimize(a1);
+      benchmark::DoNotOptimize(a2);
+
+      data.push_back(std::move(a0));
+      data.push_back(std::move(a1));
+      data.push_back(std::move(a2));
+    }
+  }
+}
+
+void BM_LargeObjectManagementWithProxy(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<pro::proxy<DefaultFacade>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; ++i) {
+      auto p = pro::make_proxy<DefaultFacade, std::array<std::string, 3>>();
+      benchmark::DoNotOptimize(p);
+      data.push_back(std::move(p));
+    }
+  }
+}
+
+void BM_LargeObjectManagementWithAny(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<std::any> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; ++i) {
+      std::any a = std::array<std::string, 3>{};
+      benchmark::DoNotOptimize(a);
+      data.push_back(std::move(a));
+    }
+  }
+}
+
+BENCHMARK(BM_SmallObjectManagementWithProxy);
+BENCHMARK(BM_SmallObjectManagementWithAny);
+BENCHMARK(BM_LargeObjectManagementWithProxy);
+BENCHMARK(BM_LargeObjectManagementWithAny);

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -33,6 +33,11 @@ struct LargeObject3 {
   void* Padding[15];
 };
 
+template <class T>
+std::pmr::unsynchronized_pool_resource CreateMemoryPool() {
+  return std::pmr::unsynchronized_pool_resource{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(T)}};
+}
+
 }  // namespace
 
 struct DefaultFacade : pro::facade_builder
@@ -47,6 +52,49 @@ void BM_SmallObjectManagementWithProxy(benchmark::State& state) {
       auto p1 = pro::make_proxy<DefaultFacade, SmallObject1>();
       auto p2 = pro::make_proxy<DefaultFacade, SmallObject2>();
       auto p3 = pro::make_proxy<DefaultFacade, SmallObject3>();
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
+    }
+  }
+}
+
+void BM_SmallObjectManagementWithSharedPtr(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<std::shared_ptr<void>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::shared_ptr<void> p1 = std::make_shared<SmallObject1>();
+      std::shared_ptr<void> p2 = std::make_shared<SmallObject2>();
+      std::shared_ptr<void> p3 = std::make_shared<SmallObject3>();
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
+    }
+  }
+}
+
+void BM_SmallObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
+  auto pool1 = CreateMemoryPool<SmallObject1>();
+  auto pool2 = CreateMemoryPool<SmallObject2>();
+  auto pool3 = CreateMemoryPool<SmallObject3>();
+  for (auto _ : state) {
+    std::vector<std::shared_ptr<void>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::shared_ptr<void> p1 = std::allocate_shared<SmallObject1>(std::pmr::polymorphic_allocator<>{&pool1});
+      std::shared_ptr<void> p2 = std::allocate_shared<SmallObject2>(std::pmr::polymorphic_allocator<>{&pool2});
+      std::shared_ptr<void> p3 = std::allocate_shared<SmallObject3>(std::pmr::polymorphic_allocator<>{&pool3});
 
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);
@@ -100,9 +148,9 @@ void BM_LargeObjectManagementWithProxy(benchmark::State& state) {
 }
 
 void BM_LargeObjectManagementWithProxy_Pooled(benchmark::State& state) {
-  static std::pmr::unsynchronized_pool_resource pool1{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject1)}};
-  static std::pmr::unsynchronized_pool_resource pool2{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject2)}};
-  static std::pmr::unsynchronized_pool_resource pool3{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject3)}};
+  auto pool1 = CreateMemoryPool<LargeObject1>();
+  auto pool2 = CreateMemoryPool<LargeObject2>();
+  auto pool3 = CreateMemoryPool<LargeObject3>();
   for (auto _ : state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
@@ -110,6 +158,49 @@ void BM_LargeObjectManagementWithProxy_Pooled(benchmark::State& state) {
       auto p1 = pro::allocate_proxy<DefaultFacade, LargeObject1>(std::pmr::polymorphic_allocator<>{&pool1});
       auto p2 = pro::allocate_proxy<DefaultFacade, LargeObject2>(std::pmr::polymorphic_allocator<>{&pool2});
       auto p3 = pro::allocate_proxy<DefaultFacade, LargeObject3>(std::pmr::polymorphic_allocator<>{&pool3});
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
+    }
+  }
+}
+
+void BM_LargeObjectManagementWithSharedPtr(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<std::shared_ptr<void>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::shared_ptr<void> p1 = std::make_shared<LargeObject1>();
+      std::shared_ptr<void> p2 = std::make_shared<LargeObject2>();
+      std::shared_ptr<void> p3 = std::make_shared<LargeObject3>();
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
+    }
+  }
+}
+
+void BM_LargeObjectManagementWithSharedPtr_Pooled(benchmark::State& state) {
+  auto pool1 = CreateMemoryPool<LargeObject1>();
+  auto pool2 = CreateMemoryPool<LargeObject2>();
+  auto pool3 = CreateMemoryPool<LargeObject3>();
+  for (auto _ : state) {
+    std::vector<std::shared_ptr<void>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::shared_ptr<void> p1 = std::allocate_shared<LargeObject1>(std::pmr::polymorphic_allocator<>{&pool1});
+      std::shared_ptr<void> p2 = std::allocate_shared<LargeObject2>(std::pmr::polymorphic_allocator<>{&pool2});
+      std::shared_ptr<void> p3 = std::allocate_shared<LargeObject3>(std::pmr::polymorphic_allocator<>{&pool3});
 
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);
@@ -143,7 +234,11 @@ void BM_LargeObjectManagementWithAny(benchmark::State& state) {
 }
 
 BENCHMARK(BM_SmallObjectManagementWithProxy);
+BENCHMARK(BM_SmallObjectManagementWithSharedPtr);
+BENCHMARK(BM_SmallObjectManagementWithSharedPtr_Pooled);
 BENCHMARK(BM_SmallObjectManagementWithAny);
 BENCHMARK(BM_LargeObjectManagementWithProxy);
 BENCHMARK(BM_LargeObjectManagementWithProxy_Pooled);
+BENCHMARK(BM_LargeObjectManagementWithSharedPtr);
+BENCHMARK(BM_LargeObjectManagementWithSharedPtr_Pooled);
 BENCHMARK(BM_LargeObjectManagementWithAny);

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -3,7 +3,8 @@
 
 #include <any>
 #include <array>
-#include <forward_list>
+#include <memory_resource>
+#include <mutex>
 #include <string>
 
 #include <benchmark/benchmark.h>
@@ -13,6 +14,24 @@
 namespace {
 
 constexpr int TestManagedObjectCount = 12000;
+constexpr int TypeSeriesCount = 3;
+
+using SmallObject1 = int;
+using SmallObject2 = std::shared_ptr<int>;
+struct SmallObject3 {
+  SmallObject3() noexcept = default;
+  SmallObject3(SmallObject3&&) noexcept = default;
+  SmallObject3(const SmallObject3&) { throw std::runtime_error{ "Not implemented" }; }
+
+  std::unique_lock<std::mutex> Field1;
+};
+
+using LargeObject1 = std::array<char, 100>;
+using LargeObject2 = std::array<std::string, 3>;
+struct LargeObject3 {
+  SmallObject3 Field1;
+  void* Padding[15];
+};
 
 }  // namespace
 
@@ -24,18 +43,18 @@ void BM_SmallObjectManagementWithProxy(benchmark::State& state) {
   for (auto _ : state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
-    for (int i = 0; i < TestManagedObjectCount; i += 3) {
-      auto p0 = pro::make_proxy<DefaultFacade>(123);
-      auto p1 = pro::make_proxy<DefaultFacade, std::shared_ptr<int>>();
-      auto p2 = pro::make_proxy<DefaultFacade, std::forward_list<double>>();
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      auto p1 = pro::make_proxy<DefaultFacade, SmallObject1>();
+      auto p2 = pro::make_proxy<DefaultFacade, SmallObject2>();
+      auto p3 = pro::make_proxy<DefaultFacade, SmallObject3>();
 
-      benchmark::DoNotOptimize(p0);
       benchmark::DoNotOptimize(p1);
       benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
 
-      data.push_back(std::move(p0));
       data.push_back(std::move(p1));
       data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
     }
   }
 }
@@ -44,18 +63,18 @@ void BM_SmallObjectManagementWithAny(benchmark::State& state) {
   for (auto _ : state) {
     std::vector<std::any> data;
     data.reserve(TestManagedObjectCount);
-    for (int i = 0; i < TestManagedObjectCount; i += 3) {
-      std::any a0 = 123;
-      std::any a1 = std::shared_ptr<int>{};
-      std::any a2 = std::forward_list<double>{};
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::any a1 = SmallObject1{};
+      std::any a2 = SmallObject2{};
+      std::any a3 = SmallObject3{};
 
-      benchmark::DoNotOptimize(a0);
       benchmark::DoNotOptimize(a1);
       benchmark::DoNotOptimize(a2);
+      benchmark::DoNotOptimize(a3);
 
-      data.push_back(std::move(a0));
       data.push_back(std::move(a1));
       data.push_back(std::move(a2));
+      data.push_back(std::move(a3));
     }
   }
 }
@@ -64,10 +83,41 @@ void BM_LargeObjectManagementWithProxy(benchmark::State& state) {
   for (auto _ : state) {
     std::vector<pro::proxy<DefaultFacade>> data;
     data.reserve(TestManagedObjectCount);
-    for (int i = 0; i < TestManagedObjectCount; ++i) {
-      auto p = pro::make_proxy<DefaultFacade, std::array<std::string, 3>>();
-      benchmark::DoNotOptimize(p);
-      data.push_back(std::move(p));
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      auto p1 = pro::make_proxy<DefaultFacade, LargeObject1>();
+      auto p2 = pro::make_proxy<DefaultFacade, LargeObject2>();
+      auto p3 = pro::make_proxy<DefaultFacade, LargeObject3>();
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
+    }
+  }
+}
+
+void BM_LargeObjectManagementWithProxy_Pooled(benchmark::State& state) {
+  static std::pmr::unsynchronized_pool_resource pool1{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject1)}};
+  static std::pmr::unsynchronized_pool_resource pool2{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject2)}};
+  static std::pmr::unsynchronized_pool_resource pool3{std::pmr::pool_options{.max_blocks_per_chunk = 1000, .largest_required_pool_block = sizeof(LargeObject3)}};
+  for (auto _ : state) {
+    std::vector<pro::proxy<DefaultFacade>> data;
+    data.reserve(TestManagedObjectCount);
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      auto p1 = pro::allocate_proxy<DefaultFacade, LargeObject1>(std::pmr::polymorphic_allocator<>{&pool1});
+      auto p2 = pro::allocate_proxy<DefaultFacade, LargeObject2>(std::pmr::polymorphic_allocator<>{&pool2});
+      auto p3 = pro::allocate_proxy<DefaultFacade, LargeObject3>(std::pmr::polymorphic_allocator<>{&pool3});
+
+      benchmark::DoNotOptimize(p1);
+      benchmark::DoNotOptimize(p2);
+      benchmark::DoNotOptimize(p3);
+
+      data.push_back(std::move(p1));
+      data.push_back(std::move(p2));
+      data.push_back(std::move(p3));
     }
   }
 }
@@ -76,10 +126,18 @@ void BM_LargeObjectManagementWithAny(benchmark::State& state) {
   for (auto _ : state) {
     std::vector<std::any> data;
     data.reserve(TestManagedObjectCount);
-    for (int i = 0; i < TestManagedObjectCount; ++i) {
-      std::any a = std::array<std::string, 3>{};
-      benchmark::DoNotOptimize(a);
-      data.push_back(std::move(a));
+    for (int i = 0; i < TestManagedObjectCount; i += TypeSeriesCount) {
+      std::any a1 = LargeObject1{};
+      std::any a2 = LargeObject2{};
+      std::any a3 = LargeObject3{};
+
+      benchmark::DoNotOptimize(a1);
+      benchmark::DoNotOptimize(a2);
+      benchmark::DoNotOptimize(a3);
+
+      data.push_back(std::move(a1));
+      data.push_back(std::move(a2));
+      data.push_back(std::move(a3));
     }
   }
 }
@@ -87,4 +145,5 @@ void BM_LargeObjectManagementWithAny(benchmark::State& state) {
 BENCHMARK(BM_SmallObjectManagementWithProxy);
 BENCHMARK(BM_SmallObjectManagementWithAny);
 BENCHMARK(BM_LargeObjectManagementWithProxy);
+BENCHMARK(BM_LargeObjectManagementWithProxy_Pooled);
 BENCHMARK(BM_LargeObjectManagementWithAny);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,21 @@
 project(msft_proxy_tests)
+
+include(FetchContent)
+# The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+# allows for proper rebuilds when a projects URL changes.
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
+  URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # For Windows: Prevent overriding the parent project's compiler/linker settings
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE) # Disable GMock
+FetchContent_MakeAvailable(googletest)
+
 add_executable(msft_proxy_tests
   proxy_creation_tests.cpp
   proxy_dispatch_tests.cpp
@@ -13,9 +30,9 @@ target_link_libraries(msft_proxy_tests PRIVATE msft_proxy)
 target_link_libraries(msft_proxy_tests PRIVATE gtest_main)
 
 if (MSVC)
-  target_compile_options(msft_proxy_tests PRIVATE /W4 /WX)
+  target_compile_options(msft_proxy_tests PRIVATE /W4)
 else()
-  target_compile_options(msft_proxy_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  target_compile_options(msft_proxy_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 include(GoogleTest)


### PR DESCRIPTION
**Changes**

- Added another folder `benchmarks` to benchmark the library in various scenarios.
- Added benchmark for invocation via `proxy` and virtual functions on small/large objects.
- Added benchmark for basic lifetime management for `proxy`, `std::unique_ptr`, `std::shared_ptr` and `std::any` for small/large objects.
- Changed the build flavor on the pipeline from "Debug" to "Release" to facilitate benchmarking.
- Due to #170, removed "treat warning as error" compiler flags.

Observed from the [CI build](https://github.com/microsoft/proxy/actions/runs/11218021763):

|                                                              | MSVC on Windows Server 2022 (x64)    | GCC on Ubuntu 24.04 (x64)            | Clang on Ubuntu 24.04 (x64)          | Apple Clang on macOS 14 (ARM64)      |
| ------------------------------------------------------------ | ------------------------------------ | ------------------------------------ | ------------------------------------ | ------------------------------------ |
| Indirect invocation on small objects via `proxy` vs. virtual functions | 🟩 `proxy` is about **254.1% faster** | 🟩 `proxy` is about **31.8% faster**  | 🟩 `proxy` is about **38.0% faster**  | 🟩 `proxy` is about **3.5% faster**   |
| Indirect invocation on large objects via `proxy` vs. virtual functions | 🟩 `proxy` is about **269.9% faster** | 🟩 `proxy` is about **28.3% faster**  | 🟩 `proxy` is about **17.4% faster**  | 🟩 `proxy` is about **2.5% faster**   |
| Basic lifetime management for small objects with `proxy` vs. `std::unique_ptr` | 🟩 `proxy` is about **375.4% faster** | 🟩 `proxy` is about **369.8% faster** | 🟩 `proxy` is about **347.1% faster** | 🟩 `proxy` is about **254.6% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::shared_ptr` (without memory pool) | 🟩 `proxy` is about **494.4% faster** | 🟩 `proxy` is about **894.4% faster** | 🟩 `proxy` is about **847.2% faster** | 🟩 `proxy` is about **355.6% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::shared_ptr` (with memory pool) | 🟩 `proxy` is about **246.5% faster** | 🟩 `proxy` is about **589.5% faster** | 🟩 `proxy` is about **566.0% faster** | 🟩 `proxy` is about **157.3% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::any` | 🟩 `proxy` is about **61.6% faster**  | 🟩 `proxy` is about **235.7% faster** | 🟩 `proxy` is about **222.5% faster** | 🟩 `proxy` is about **20.0% faster**  |
| Basic lifetime management for large objects with `proxy` (without memory pool) vs. `std::unique_ptr` | 🟥 `proxy` is about **0.5% slower**   | 🟥 `proxy` is about **2.7% slower**   | 🟩 `proxy` is about **7.4% faster**   | 🟥 `proxy` is about **8.0% slower**   |
| Basic lifetime management for large objects with `proxy` (with memory pool) vs. `std::unique_ptr` | 🟩 `proxy` is about **117.4% faster** | 🟩 `proxy` is about **113.6% faster** | 🟩 `proxy` is about **161.1% faster** | 🟩 `proxy` is about **88.5% faster**  |
| Basic lifetime management for large objects with `proxy` vs. `std::shared_ptr` (both without memory pool) | 🟩 `proxy` is about **12.1% faster**  | 🟩 `proxy` is about **5.9% faster**   | 🟩 `proxy` is about **16.0% faster**  | 🟩 `proxy` is about **11.5% faster**  |
| Basic lifetime management for large objects with `proxy` vs. `std::shared_ptr` (both with memory pool) | 🟩 `proxy` is about **8.7% faster**   | 🟩 `proxy` is about **16.4% faster**  | 🟩 `proxy` is about **8.6% faster**   | 🟩 `proxy` is about **46.8% faster**  |
| Basic lifetime management for large objects with `proxy` (without memory pool) vs. `std::any` | 🟩 `proxy` is about **33.6% faster**  | 🟥 `proxy` is about **6.2% slower**   | 🟩 `proxy` is about **5.5% faster**   | 🟩 `proxy` is about **3.7% faster**   |
| Basic lifetime management for large objects with `proxy` (with memory pool) vs. `std::any` | 🟩 `proxy` is about **192.1% faster** | 🟩 `proxy` is about **105.9% faster** | 🟩 `proxy` is about **156.4% faster** | 🟩 `proxy` is about **112.5% faster** |

**Notes**

- Invocation benchmarks are performed against 1,000,000 objects of 100 types. Specifically,
  - A small object in the invocation benchmarks contains a single `int` field.
  - A large object in the invocation benchmarks contains 15 pointers (`void*`) and a single `int` field.
- Lifetime management benchmarks are performed against 120,000 objects. Specifically,
  - 3 types of small objects are used for testing: `int`, `std::shared_ptr<int>` and `std::unique_lock<std::mutex>`.
  - `std::array<char, 100>`, `std::array<std::string, 3>` and `std::unique_lock<std::mutex> padded with void*[15]` are used as large object.
  - For benchmarks involving memory pool, `std::pmr::unsynchronized_pool_resource` is used.