### PR TITLE
Resolve warnings in unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,9 +30,9 @@ target_link_libraries(msft_proxy_tests PRIVATE msft_proxy)
 target_link_libraries(msft_proxy_tests PRIVATE gtest_main)
 
 if (MSVC)
-  target_compile_options(msft_proxy_tests PRIVATE /W4)
+  target_compile_options(msft_proxy_tests PRIVATE /W4 /WX)
 else()
-  target_compile_options(msft_proxy_tests PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(msft_proxy_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
 
 include(GoogleTest)

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -11,7 +11,14 @@
 #include <typeindex>
 #include <typeinfo>
 #include <vector>
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable: 4702)  // False alarm from MSVC: warning C4702: unreachable code
+#endif  // defined(_MSC_VER) && !defined(__clang__)
 #include "proxy.h"
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif  // defined(_MSC_VER) && !defined(__clang__)
 #include "utils.h"
 
 namespace {

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -805,24 +805,38 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToNull) {
 }
 
 TEST(ProxyLifetimeTests, TestHasValue) {
-  int foo = 123;
-  pro::proxy<TestFacade> p1;
-  ASSERT_FALSE(p1.has_value());
-  p1 = &foo;
-  ASSERT_TRUE(p1.has_value());
-  ASSERT_EQ(ToString(*p1), "123");
+  utils::LifetimeTracker tracker;
+  std::vector<utils::LifetimeOperation> expected_ops;
+  {
+    pro::proxy<TestFacade> p;
+    ASSERT_FALSE(p.has_value());
+    p.emplace<utils::LifetimeTracker::Session>(&tracker);
+    ASSERT_TRUE(p.has_value());
+    ASSERT_EQ(ToString(*p), "Session 1");
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
+    ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+  }
+  expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+  ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
 TEST(ProxyLifetimeTests, TestOperatorBool) {
   // Implicit conversion to bool shall be prohibited.
   static_assert(!std::is_nothrow_convertible_v<pro::proxy<TestFacade>, bool>);
 
-  int foo = 123;
-  pro::proxy<TestFacade> p1;
-  ASSERT_FALSE(static_cast<bool>(p1));
-  p1 = &foo;
-  ASSERT_TRUE(static_cast<bool>(p1));
-  ASSERT_EQ(ToString(*p1), "123");
+  utils::LifetimeTracker tracker;
+  std::vector<utils::LifetimeOperation> expected_ops;
+  {
+    pro::proxy<TestFacade> p;
+    ASSERT_FALSE(static_cast<bool>(p));
+    p.emplace<utils::LifetimeTracker::Session>(&tracker);
+    ASSERT_TRUE(static_cast<bool>(p));
+    ASSERT_EQ(ToString(*p), "Session 1");
+    expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
+    ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+  }
+  expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
+  ASSERT_TRUE(tracker.GetOperations() == expected_ops);
 }
 
 TEST(ProxyLifetimeTests, TestEqualsToNullptr) {


### PR DESCRIPTION
**Changes**

- Resolved warnings in GCC and MSVC. Closes #170 
- Re-enabled "treat warning as error"