### PR TITLE
Stabilize benchmarking report

### DIFF
--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -27,7 +27,7 @@ jobs:
     - name: run benchmarks
       run: |
         cd build/benchmarks
-        ./msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true --benchmark_enable_random_interleaving=true --benchmark_out=benchmarking-results.json
+        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -51,7 +51,7 @@ jobs:
     - name: run benchmarks
       run: |
         cd build-clang-18/benchmarks
-        ./msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true --benchmark_enable_random_interleaving=true --benchmark_out=benchmarking-results.json
+        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -51,7 +51,7 @@ jobs:
     - name: run benchmarks
       run: |
         cd build-gcc-14/benchmarks
-        ./msft_proxy_benchmarks --benchmark_repetitions=10 --benchmark_report_aggregates_only=true --benchmark_enable_random_interleaving=true --benchmark_out=benchmarking-results.json
+        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/bvt-msvc.yml
+++ b/.github/workflows/bvt-msvc.yml
@@ -22,7 +22,7 @@ jobs:
     - name: run benchmarks
       run: |
         cd build\benchmarks
-        .\Release\msft_proxy_benchmarks.exe --benchmark_repetitions=10 --benchmark_report_aggregates_only=true --benchmark_enable_random_interleaving=true --benchmark_out=benchmarking-results.json
+        .\Release\msft_proxy_benchmarks.exe --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, release/** ]
   pull_request:
     branches: [ main, release/** ]
+  workflow_dispatch:
 
 jobs:
   run-bvt-gcc:

--- a/benchmarks/proxy_invocation_benchmark.cpp
+++ b/benchmarks/proxy_invocation_benchmark.cpp
@@ -5,9 +5,12 @@
 
 #include "proxy_invocation_benchmark_context.h"
 
+namespace {
+
 void BM_SmallObjectInvocationViaProxy(benchmark::State& state) {
+  auto data = GenerateSmallObjectInvocationProxyTestData();
   for (auto _ : state) {
-    for (auto& p : SmallObjectInvocationProxyTestData) {
+    for (auto& p : data) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
@@ -15,8 +18,9 @@ void BM_SmallObjectInvocationViaProxy(benchmark::State& state) {
 }
 
 void BM_SmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  auto data = GenerateSmallObjectInvocationVirtualFunctionTestData();
   for (auto _ : state) {
-    for (auto& p : SmallObjectInvocationVirtualFunctionTestData) {
+    for (auto& p : data) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
@@ -24,8 +28,9 @@ void BM_SmallObjectInvocationViaVirtualFunction(benchmark::State& state) {
 }
 
 void BM_LargeObjectInvocationViaProxy(benchmark::State& state) {
+  auto data = GenerateLargeObjectInvocationProxyTestData();
   for (auto _ : state) {
-    for (auto& p : LargeObjectInvocationProxyTestData) {
+    for (auto& p : data) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
@@ -33,8 +38,9 @@ void BM_LargeObjectInvocationViaProxy(benchmark::State& state) {
 }
 
 void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
+  auto data = GenerateLargeObjectInvocationVirtualFunctionTestData();
   for (auto _ : state) {
-    for (auto& p : LargeObjectInvocationVirtualFunctionTestData) {
+    for (auto& p : data) {
       int result = p->Fun();
       benchmark::DoNotOptimize(result);
     }
@@ -45,3 +51,5 @@ BENCHMARK(BM_SmallObjectInvocationViaProxy);
 BENCHMARK(BM_SmallObjectInvocationViaVirtualFunction);
 BENCHMARK(BM_LargeObjectInvocationViaProxy);
 BENCHMARK(BM_LargeObjectInvocationViaVirtualFunction);
+
+}  // namespace

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -27,7 +27,7 @@ class NonIntrusiveLargeImpl {
   int Fun() const noexcept { return seed_ ^ (TypeSeries + 1); }
 
  private:
-  void* padding_[7]{};
+  void* padding_[5]{};
   int seed_;
 };
 
@@ -50,7 +50,7 @@ class IntrusiveLargeImpl : public InvocationTestBase {
   int Fun() const noexcept override { return seed_ ^ (TypeSeries + 1); }
 
  private:
-  void* padding_[7]{};
+  void* padding_[5]{};
   int seed_;
 };
 

--- a/benchmarks/proxy_invocation_benchmark_context.cpp
+++ b/benchmarks/proxy_invocation_benchmark_context.cpp
@@ -27,7 +27,7 @@ class NonIntrusiveLargeImpl {
   int Fun() const noexcept { return seed_ ^ (TypeSeries + 1); }
 
  private:
-  void* padding_[15]{};
+  void* padding_[7]{};
   int seed_;
 };
 
@@ -50,7 +50,7 @@ class IntrusiveLargeImpl : public InvocationTestBase {
   int Fun() const noexcept override { return seed_ ^ (TypeSeries + 1); }
 
  private:
-  void* padding_[16]{};
+  void* padding_[7]{};
   int seed_;
 };
 
@@ -76,18 +76,19 @@ auto GenerateTestData(const F& generator) {
 
 }  // namespace
 
-const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
-        { return pro::make_proxy<InvocationTestFacade, NonIntrusiveSmallImpl<TypeSeries>>(seed); });
-
-const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
-        { return std::unique_ptr<InvocationTestBase>{new IntrusiveSmallImpl<TypeSeries>(seed)}; });
-
-const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
-        { return pro::make_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(seed); });
-
-const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData = GenerateTestData(
-    []<int TypeSeries>(IntConstant<TypeSeries>, int seed)
-        { return std::unique_ptr<InvocationTestBase>{new IntrusiveLargeImpl<TypeSeries>(seed)}; });
+std::vector<pro::proxy<InvocationTestFacade>> GenerateSmallObjectInvocationProxyTestData() {
+  return GenerateTestData([]<int TypeSeries>(IntConstant<TypeSeries>, int seed)
+      { return pro::make_proxy<InvocationTestFacade, NonIntrusiveSmallImpl<TypeSeries>>(seed); });
+}
+std::vector<std::unique_ptr<InvocationTestBase>> GenerateSmallObjectInvocationVirtualFunctionTestData() {
+  return GenerateTestData([]<int TypeSeries>(IntConstant<TypeSeries>, int seed)
+      { return std::unique_ptr<InvocationTestBase>{new IntrusiveSmallImpl<TypeSeries>(seed)}; });
+}
+std::vector<pro::proxy<InvocationTestFacade>> GenerateLargeObjectInvocationProxyTestData() {
+  return GenerateTestData([]<int TypeSeries>(IntConstant<TypeSeries>, int seed)
+      { return pro::make_proxy<InvocationTestFacade, NonIntrusiveLargeImpl<TypeSeries>>(seed); });
+}
+std::vector<std::unique_ptr<InvocationTestBase>> GenerateLargeObjectInvocationVirtualFunctionTestData() {
+  return GenerateTestData([]<int TypeSeries>(IntConstant<TypeSeries>, int seed)
+      { return std::unique_ptr<InvocationTestBase>{new IntrusiveLargeImpl<TypeSeries>(seed)}; });
+}

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -17,7 +17,7 @@ struct InvocationTestBase {
   virtual ~InvocationTestBase() = default;
 };
 
-extern const std::vector<pro::proxy<InvocationTestFacade>> SmallObjectInvocationProxyTestData;
-extern const std::vector<std::unique_ptr<InvocationTestBase>> SmallObjectInvocationVirtualFunctionTestData;
-extern const std::vector<pro::proxy<InvocationTestFacade>> LargeObjectInvocationProxyTestData;
-extern const std::vector<std::unique_ptr<InvocationTestBase>> LargeObjectInvocationVirtualFunctionTestData;
+std::vector<pro::proxy<InvocationTestFacade>> GenerateSmallObjectInvocationProxyTestData();
+std::vector<std::unique_ptr<InvocationTestBase>> GenerateSmallObjectInvocationVirtualFunctionTestData();
+std::vector<pro::proxy<InvocationTestFacade>> GenerateLargeObjectInvocationProxyTestData();
+std::vector<std::unique_ptr<InvocationTestBase>> GenerateLargeObjectInvocationVirtualFunctionTestData();

--- a/benchmarks/proxy_management_benchmark.cpp
+++ b/benchmarks/proxy_management_benchmark.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-constexpr int TestManagedObjectCount = 120000;
+constexpr int TestManagedObjectCount = 600000;
 constexpr int TypeSeriesCount = 3;
 
 using SmallObject1 = int;
@@ -40,8 +40,6 @@ template <class T>
 struct PolymorphicObject : PolymorphicObjectBase {
   T Value;
 };
-
-}  // namespace
 
 struct DefaultFacade : pro::facade_builder
     ::support_copy<pro::constraint_level::nontrivial>
@@ -207,3 +205,5 @@ BENCHMARK(BM_LargeObjectManagementWithUniquePtr);
 BENCHMARK(BM_LargeObjectManagementWithSharedPtr);
 BENCHMARK(BM_LargeObjectManagementWithSharedPtr_Pooled);
 BENCHMARK(BM_LargeObjectManagementWithAny);
+
+}  // namespace


### PR DESCRIPTION
**Changes**

- Updated benchmarking command line:
  - Added `benchmark_min_warmup_time=0.1` to warmup each benchmark.
  - Changed `benchmark_repetitions` from `10` to `30` to get more test results.
  - Added `--benchmark_min_time=0.1s` to keep the overall execution time similar with before.
  - Added `benchmark_enable_random_interleaving=true` to avoid transient high load.
- For invocation benchmarks `BM_SmallObjectInvocationViaProxy`, `BM_SmallObjectInvocationViaVirtualFunction`, `BM_LargeObjectInvocationViaProxy` and `BM_LargeObjectInvocationViaVirtualFunction`, moved data preparation from global to each function body to make sure each case runs from a clean state.
- Changed padding of large objects from `15 * sizeof(void*)` into `5 * sizeof(void*)` to have less effects on heap allocation.
- For lifetime management benchmarks, changed test object count from `12,000` into `30,000` for better differentiation.
- Enabled `workflow_dispatch` for CI pipeline to facilitate benchmarking.

Here's the report generated from the CI build of this PR.

## Benchmarking Report

- Generated for: [Microsoft "Proxy" library](https://github.com/microsoft/proxy)
- Commit ID: [d7c03d69abc3e0d7a27308fd1435d62937687500](https://github.com/microsoft/proxy/commit/d7c03d69abc3e0d7a27308fd1435d62937687500)
- Generated at: 2024-10-27T16:12:39.965376946Z

| | MSVC on Windows Server 2022 (x64) | GCC on Ubuntu 24.04 (x64) | Clang on Ubuntu 24.04 (x64) | Apple Clang on macOS 15 (ARM64) |
| - | - | - | - | - |
| Indirect invocation on small objects via `proxy` vs. virtual functions | 🟢`proxy` is about **233.7% faster** | 🟢`proxy` is about **39.5% faster** | 🟢`proxy` is about **44.7% faster** | 🟢`proxy` is about **6.7% faster** |
| Indirect invocation on large objects via `proxy` vs. virtual functions | 🟢`proxy` is about **173.2% faster** | 🟢`proxy` is about **16.2% faster** | 🟢`proxy` is about **14.8% faster** | 🟢`proxy` is about **10.2% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::unique_ptr` | 🟢`proxy` is about **439.1% faster** | 🟢`proxy` is about **87.2% faster** | 🟢`proxy` is about **378.3% faster** | 🟢`proxy` is about **302.0% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::shared_ptr` (without memory pool) | 🟢`proxy` is about **672.9% faster** | 🟢`proxy` is about **115.4% faster** | 🟢`proxy` is about **492.3% faster** | 🟢`proxy` is about **438.8% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::shared_ptr` (with memory pool) | 🟢`proxy` is about **187.4% faster** | 🟢`proxy` is about **181.4% faster** | 🟢`proxy` is about **652.7% faster** | 🟢`proxy` is about **156.1% faster** |
| Basic lifetime management for small objects with `proxy` vs. `std::any` | 🟢`proxy` is about **56.2% faster** | 🟢`proxy` is about **47.7% faster** | 🟢`proxy` is about **323.8% faster** | 🟢`proxy` is about **14.1% faster** |
| Basic lifetime management for large objects with `proxy` (without memory pool) vs. `std::unique_ptr` | 🟢`proxy` is about **18.7% faster** | 🟢`proxy` is about **8.1% faster** | 🟢`proxy` is about **11.7% faster** | 🔴`proxy` is about **5.6% slower** |
| Basic lifetime management for large objects with `proxy` (with memory pool) vs. `std::unique_ptr` | 🟢`proxy` is about **265.8% faster** | 🟢`proxy` is about **90.7% faster** | 🟢`proxy` is about **130.8% faster** | 🟢`proxy` is about **93.1% faster** |
| Basic lifetime management for large objects with `proxy` vs. `std::shared_ptr` (both without memory pool) | 🟢`proxy` is about **34.1% faster** | 🟢`proxy` is about **5.3% faster** | 🟢`proxy` is about **7.6% faster** | 🟢`proxy` is about **5.6% faster** |
| Basic lifetime management for large objects with `proxy` vs. `std::shared_ptr` (both with memory pool) | 🟢`proxy` is about **8.9% faster** | 🟢`proxy` is about **9.4% faster** | 🟢`proxy` is about **16.7% faster** | 🟢`proxy` is about **42.9% faster** |
| Basic lifetime management for large objects with `proxy` (without memory pool) vs. `std::any` | 🟢`proxy` is about **15.3% faster** | 🟡`proxy` is about **3.1% slower** | 🟡`proxy` is about **1.0% faster** | 🟢`proxy` is about **5.9% faster** |
| Basic lifetime management for large objects with `proxy` (with memory pool) vs. `std::any` | 🟢`proxy` is about **255.5% faster** | 🟢`proxy` is about **71.0% faster** | 🟢`proxy` is about **108.6% faster** | 🟢`proxy` is about **116.5% faster** |
