### PR TITLE
Add pipeline for NVHPC

### DIFF
--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
+
+jobs:
+  bvt-nvhpc:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: install NVHPC 24.9
+      run: |
+        curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+        echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+        sudo apt-get update -y
+        sudo apt-get install -y nvhpc-24-9
+
+    - name: build and run test with NVHPC 24.9
+      run: |
+        PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.9/compilers/bin:$PATH; export PATH
+        cmake -B build-nv -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++ -DCMAKE_BUILD_TYPE=Release
+        cmake --build build-nv -j
+        ctest --test-dir build-nv -j
+
+    - name: run benchmarks
+      run: |
+        cd build-nv/benchmarks
+        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+
+    - name: archive benchmarking results
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmarking-results-nvhpc
+        path: build-nv/benchmarks/benchmarking-results.json

--- a/.github/workflows/bvt-report.yml
+++ b/.github/workflows/bvt-report.yml
@@ -26,7 +26,15 @@ jobs:
 
     - name: generate report
       run: |
-        tools/report_generator/build/report_generator tools/report_generator/report-config.json ${{ github.sha }} artifacts benchmarking-report.md
+        cat <<EOF > benchmarking-report.md
+        ## Benchmarking Report
+
+        - Generated for: [Microsoft "Proxy" library](https://github.com/microsoft/proxy)
+        - Commit ID: [${{ github.sha }}](https://github.com/microsoft/proxy/commit/${{ github.sha }})
+        - Generated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        EOF
+        tools/report_generator/build/report_generator tools/report_generator/report-config.json
 
     - name: archive benchmarking report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -24,7 +24,11 @@ jobs:
     uses: ./.github/workflows/bvt-appleclang.yml
     name: Run BVT with AppleClang
 
+  run-bvt-nvhpc:
+    uses: ./.github/workflows/bvt-nvhpc.yml
+    name: Run BVT with NVHPC
+
   report:
     uses: ./.github/workflows/bvt-report.yml
     name: Generate report
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang]
+    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc]

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -65,14 +65,21 @@ jobs:
     with:
       branch: release/${{ github.event.inputs.version }}
 
+  run-bvt-nvhpc:
+    needs: prepare-release
+    name: Run BVT with NVHPC
+    uses: ./.github/workflows/bvt-nvhpc.yml
+    with:
+      branch: release/${{ github.event.inputs.version }}
+
   report:
     uses: ./.github/workflows/bvt-report.yml
     name: Generate report
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang]
+    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc]
 
   draft-release:
     runs-on: windows-latest
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang]
+    needs: report
     steps:
     - uses: actions/checkout@v3
       with:

--- a/README.md
+++ b/README.md
@@ -164,11 +164,12 @@ The "Proxy" library is a self-contained solution for runtime polymorphism in C++
 
 ## <a name="compiler-req">Minimum Requirements for Compilers</a>
 
-| Family | Minimum version | Required flags |
-| ------ | --------------- | -------------- |
-| clang  | 15.0.0          | -std=c++20     |
-| gcc    | 11.2            | -std=c++20     |
-| MSVC   | 19.30           | /std:c++20     |
+| Family     | Minimum version | Required flags |
+| ---------- | --------------- | -------------- |
+| GCC        | 11.2            | -std=c++20     |
+| Clang      | 15.0.0          | -std=c++20     |
+| MSVC       | 19.30           | /std:c++20     |
+| NVIDIA HPC | 24.1            | -std=c++20     |
 
 ## Build and Run Tests with CMake
 
@@ -182,9 +183,10 @@ ctest --test-dir build -j
 
 ## Related Resources
 
+- November, 2024: [Analyzing the Performance of the “Proxy” Library](https://devblogs.microsoft.com/cppblog/analyzing-the-performance-of-the-proxy-library/)
+- September, 2024: [Announcing the Proxy 3 Library for Dynamic Polymorphism](https://devblogs.microsoft.com/cppblog/announcing-the-proxy-3-library-for-dynamic-polymorphism/)
 - April, 2024: [Published ISO C++ proposal P3086R2: Proxy: A Pointer-Semantics-Based Polymorphism Library](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3086r2.pdf)
 - August, 2022: [proxy: Runtime Polymorphism Made Easier Than Ever](https://devblogs.microsoft.com/cppblog/proxy-runtime-polymorphism-made-easier-than-ever/)
-- September, 2024: [Announcing the Proxy 3 Library for Dynamic Polymorphism](https://devblogs.microsoft.com/cppblog/announcing-the-proxy-3-library-for-dynamic-polymorphism/)
 
 ## Contributing
 

--- a/tools/report_generator/report-config.json
+++ b/tools/report_generator/report-config.json
@@ -1,22 +1,27 @@
 {
   "TargetName": "`proxy`",
   "YellowIndicatorThreshold": 5.0,
+  "OutputPath": "benchmarking-report.md",
   "Environments": [
     {
-      "Name": "msvc",
-      "Description": "MSVC on Windows Server 2022 (x64)"
+      "Description": "MSVC on Windows Server 2022 (x64)",
+      "Path": "artifacts/benchmarking-results-msvc/benchmarking-results.json"
     },
     {
-      "Name": "gcc",
-      "Description": "GCC on Ubuntu 24.04 (x64)"
+      "Description": "GCC on Ubuntu 24.04 (x64)",
+      "Path": "artifacts/benchmarking-results-gcc/benchmarking-results.json"
     },
     {
-      "Name": "clang",
-      "Description": "Clang on Ubuntu 24.04 (x64)"
+      "Description": "Clang on Ubuntu 24.04 (x64)",
+      "Path": "artifacts/benchmarking-results-clang/benchmarking-results.json"
     },
     {
-      "Name": "appleclang",
-      "Description": "Apple Clang on macOS 15 (ARM64)"
+      "Description": "Apple Clang on macOS 15 (ARM64)",
+      "Path": "artifacts/benchmarking-results-appleclang/benchmarking-results.json"
+    },
+    {
+      "Description": "Nvidia HPC on Ubuntu 24.04 (x64)",
+      "Path": "artifacts/benchmarking-results-nvhpc/benchmarking-results.json"
     }
   ],
   "Metrics": [


### PR DESCRIPTION
**Motivation**

Ensure #180 won't regress.

**Changes**

- Added pipeline for the NVIDIA HPC compiler, and updated `README.md` accordingly.
- Added benchmarking for NVHPC 24.9.
- Decoupled any knowledge of `proxy` from `report_generator` to facilitate maintenance of the tool.
- Noticed #196 during this work.

No functional changes. Resolves #186.