### PR TITLE
Improve accessibility in debugging

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -532,13 +532,18 @@ struct indirection_accessor {
       &indirection_accessor::operator*, &indirection_accessor::operator*};
 #endif  // NODEBUG
 };
+struct empty_proxy_base {};
 template <class F, class IA, class DA>
-struct proxy_base_traits : std::type_identity<DA> {};
+struct proxy_base_traits : std::type_identity<empty_proxy_base> {};
 template <class F, class... IAs, class... DAs> requires(sizeof...(IAs) > 0u)
 struct proxy_base_traits<F, composite_accessor_impl<IAs...>,
     composite_accessor_impl<DAs...>>
     : std::type_identity<composite_accessor_impl<
           indirection_accessor<F, composite_accessor_impl<IAs...>>, DAs...>> {};
+template <class F, class... DAs> requires(sizeof...(DAs) > 0u)
+struct proxy_base_traits<F, composite_accessor_impl<>,
+    composite_accessor_impl<DAs...>>
+    : std::type_identity<composite_accessor_impl<DAs...>> {};
 
 template <class F>
 consteval bool is_facade_constraints_well_formed() {

--- a/proxy.h
+++ b/proxy.h
@@ -572,16 +572,21 @@ struct facade_traits<F>
   using direct_accessor = merged_composite_accessor<
       typename facade_traits::conv_direct_accessor,
       typename facade_traits::refl_direct_accessor>;
-  static constexpr bool has_indirection =
+  static constexpr bool has_indirect_accessor =
       !std::is_same_v<indirect_accessor, composite_accessor_impl<>>;
+  static constexpr bool has_direct_accessor =
+      !std::is_same_v<direct_accessor, composite_accessor_impl<>>;
 };
 
 template <class F>
 struct proxy_indirect_accessor : facade_traits<F>::indirect_accessor {};
 
+template <class F> class proxy_base {};
 template <class F>
-class proxy_base : public facade_traits<F>::direct_accessor {};
-template <class F> requires(facade_traits<F>::has_indirection)
+    requires(facade_traits<F>::has_direct_accessor &&
+        !facade_traits<F>::has_indirect_accessor)
+class proxy_base<F> : public facade_traits<F>::direct_accessor {};
+template <class F> requires(facade_traits<F>::has_indirect_accessor)
 class proxy_base<F> : public facade_traits<F>::direct_accessor {
   using _IA = proxy_indirect_accessor<F>;
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -49,25 +49,13 @@ struct TestMemFn0 : pro::facade_builder
     ::build {};
 struct TestMemFn0_Normal { void MemFn0(int) noexcept {} };
 static_assert(pro::proxiable<TestMemFn0_Normal*, TestMemFn0>);
-#ifdef __NVCOMPILER
-#pragma diag_suppress declared_but_not_referenced
-#endif  // __NVCOMPILER
 struct TestMemFn0_Unsupproted { void MemFn1(int) noexcept {} };
-#ifdef __NVCOMPILER
-#pragma diag_default declared_but_not_referenced
-#endif  // __NVCOMPILER
 static_assert(!pro::proxiable<TestMemFn0_Unsupproted*, TestMemFn0>);
 struct TestMemFn0_MissingNoexcept { void MemFn0(int) {} };
 static_assert(!pro::proxiable<TestMemFn0_MissingNoexcept*, TestMemFn0>);
 struct TestMemFn0_ArgumentConvertible { void MemFn0(std::int64_t&&) noexcept {} };
 static_assert(pro::proxiable<TestMemFn0_ArgumentConvertible*, TestMemFn0>);
-#ifdef __NVCOMPILER
-#pragma diag_suppress declared_but_not_referenced
-#endif  // __NVCOMPILER
 struct TestMemFn0_ArgumentNotMatch { void MemFn0(int&) noexcept {} };
-#ifdef __NVCOMPILER
-#pragma diag_default declared_but_not_referenced
-#endif  // __NVCOMPILER
 static_assert(!pro::proxiable<TestMemFn0_ArgumentNotMatch*, TestMemFn0>);
 struct TestMemFn0_ReturnTypeNotMatch { std::string MemFn0(int) noexcept { return {}; } };
 static_assert(pro::proxiable<TestMemFn0_ReturnTypeNotMatch*, TestMemFn0>);

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -12,7 +12,7 @@
 #pragma warning(pop)
 #endif  // defined(_MSC_VER) && !defined(__clang__)
 
-namespace {
+namespace proxy_dispatch_tests_details {
 
 struct CommaTester {
 public:
@@ -35,7 +35,9 @@ private:
 
 PRO_DEF_FREE_AS_MEM_DISPATCH(FreeMemToString, std::to_string, ToString);
 
-}  // namespace
+}  // namespace proxy_dispatch_tests_details
+
+namespace details = proxy_dispatch_tests_details;
 
 TEST(ProxyDispatchTests, TestOpPlus) {
   struct TestFacade : pro::facade_builder::add_convention<pro::operator_dispatch<"+">, int(), int(int val)>::build {};
@@ -297,7 +299,7 @@ TEST(ProxyDispatchTests, TestOpRightShiftAssignment) {
 
 TEST(ProxyDispatchTests, TestOpComma) {
   struct TestFacade : pro::facade_builder::add_convention<pro::operator_dispatch<",">, int(int val)>::build {};
-  CommaTester v{3};
+  details::CommaTester v{3};
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ((*p, 6), 9);
 }
@@ -572,14 +574,14 @@ TEST(ProxyDispatchTests, TestRhsOpRightShiftAssignment) {
 
 TEST(ProxyDispatchTests, TestRhsOpComma) {
   struct TestFacade : pro::facade_builder::add_convention<pro::operator_dispatch<",", true>, int(int val)>::build {};
-  CommaTester v{3};
+  details::CommaTester v{3};
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ((7, *p), 21);
 }
 
 TEST(ProxyDispatchTests, TestRhsOpPtrToMem) {
   struct TestFacade : pro::facade_builder::add_convention<pro::operator_dispatch<"->*", true>, int(int val)>::build {};
-  PtrToMemTester v{3};
+  details::PtrToMemTester v{3};
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ(2->**p, 6);
 }
@@ -618,7 +620,7 @@ TEST(ProxyDispatchTests, TestImplciitConversion) {
 }
 
 TEST(ProxyDispatchTests, TestFreeAsMemDispatch) {
-  struct TestFacade : pro::facade_builder::add_convention<FreeMemToString, std::string() const>::build {};
+  struct TestFacade : pro::facade_builder::add_convention<details::FreeMemToString, std::string() const>::build {};
   int v = 123;
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ(p->ToString(), "123");

--- a/tests/proxy_integration_tests.cpp
+++ b/tests/proxy_integration_tests.cpp
@@ -11,9 +11,7 @@
 #include <vector>
 #include "proxy.h"
 
-namespace {
-
-namespace spec {
+namespace proxy_integration_tests_details {
 
 PRO_DEF_MEM_DISPATCH(MemDraw, Draw);
 PRO_DEF_MEM_DISPATCH(MemArea, Area);
@@ -28,8 +26,6 @@ PRO_DEF_MEM_DISPATCH(MemLog, Log);
 struct Logger : pro::facade_builder
     ::add_convention<MemLog, void(const char*), void(const char*, const std::exception&)>
     ::build {};
-
-}  // namespace spec
 
 class Rectangle {
  public:
@@ -61,7 +57,7 @@ class Point {
   constexpr double Area() const noexcept { return 0; }
 };
 
-std::string PrintDrawableToString(pro::proxy<spec::Drawable> p) {
+std::string PrintDrawableToString(pro::proxy<Drawable> p) {
   std::stringstream result;
   result << std::fixed << std::setprecision(5) << "shape = ";
   p->Draw(result);
@@ -92,19 +88,19 @@ std::vector<std::string> ParseCommand(const std::string& s) {
   return result;
 }
 
-pro::proxy<spec::Drawable> MakeDrawableFromCommand(const std::string& s) {
+pro::proxy<Drawable> MakeDrawableFromCommand(const std::string& s) {
   std::vector<std::string> parsed = ParseCommand(s);
   if (!parsed.empty()) {
     if (parsed[0u] == "Rectangle") {
       if (parsed.size() == 3u) {
         static std::pmr::unsynchronized_pool_resource rectangle_memory_pool;
         std::pmr::polymorphic_allocator<> alloc{&rectangle_memory_pool};
-        return pro::allocate_proxy<spec::Drawable, Rectangle>(alloc, std::stod(parsed[1u]), std::stod(parsed[2u]));
+        return pro::allocate_proxy<Drawable, Rectangle>(alloc, std::stod(parsed[1u]), std::stod(parsed[2u]));
       }
     } else if (parsed[0u] == "Circle") {
       if (parsed.size() == 2u) {
         Circle circle{std::stod(parsed[1u])};
-        return pro::make_proxy<spec::Drawable>(circle);
+        return pro::make_proxy<Drawable>(circle);
       }
     } else if (parsed[0u] == "Point") {
       if (parsed.size() == 1u) {
@@ -132,23 +128,25 @@ class StreamLogger {
   std::ostream* out_;
 };
 
-}  // namespace
+}  // namespace proxy_integration_tests_details
+
+namespace details = proxy_integration_tests_details;
 
 TEST(ProxyIntegrationTests, TestDrawable) {
-  pro::proxy<spec::Drawable> p = MakeDrawableFromCommand("Rectangle 2 3");
-  std::string s = PrintDrawableToString(std::move(p));
+  pro::proxy<details::Drawable> p = details::MakeDrawableFromCommand("Rectangle 2 3");
+  std::string s = details::PrintDrawableToString(std::move(p));
   ASSERT_EQ(s, "shape = {Rectangle: width = 2.00000, height = 3.00000}, area = 6.00000");
 
-  p = MakeDrawableFromCommand("Circle 1");
-  s = PrintDrawableToString(std::move(p));
+  p = details::MakeDrawableFromCommand("Circle 1");
+  s = details::PrintDrawableToString(std::move(p));
   ASSERT_EQ(s, "shape = {Circle: radius = 1.00000}, area = 3.14159");
 
-  p = MakeDrawableFromCommand("Point");
-  s = PrintDrawableToString(std::move(p));
+  p = details::MakeDrawableFromCommand("Point");
+  s = details::PrintDrawableToString(std::move(p));
   ASSERT_EQ(s, "shape = {Point}, area = 0.00000");
 
   try {
-    p = MakeDrawableFromCommand("Triangle 2 3");
+    p = details::MakeDrawableFromCommand("Triangle 2 3");
   } catch (const std::runtime_error& e) {
     ASSERT_STREQ(e.what(), "Invalid command");
   }
@@ -156,7 +154,7 @@ TEST(ProxyIntegrationTests, TestDrawable) {
 
 TEST(ProxyIntegrationTests, TestLogger) {
   std::ostringstream out;
-  auto logger = pro::make_proxy<spec::Logger, StreamLogger>(out);
+  auto logger = pro::make_proxy<details::Logger, details::StreamLogger>(out);
   logger->Log("hello");
   try {
     throw std::runtime_error{"runtime error!"};

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -5,7 +5,7 @@
 #include "proxy.h"
 #include "utils.h"
 
-namespace {
+namespace proxy_lifetime_tests_details {
 
 struct TestFacade : pro::facade_builder
     ::add_convention<utils::spec::FreeToString, std::string()>
@@ -30,15 +30,17 @@ struct TestRttiFacade : pro::facade_builder
 static_assert(!std::is_convertible_v<pro::proxy<TestTrivialFacade>, pro::proxy<utils::spec::Stringable>>);
 static_assert(std::is_convertible_v<pro::proxy<TestRttiFacade>, pro::proxy<TestFacade>>);
 
-}  // namespace
+}  // namespace proxy_lifetime_tests_details
+
+namespace details = proxy_lifetime_tests_details;
 
 TEST(ProxyLifetimeTests, TestDefaultConstrction) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
   ASSERT_FALSE(p.has_value());
 }
 
 TEST(ProxyLifetimeTests, TestNullConstrction) {
-  pro::proxy<TestFacade> p = nullptr;
+  pro::proxy<details::TestFacade> p = nullptr;
   ASSERT_FALSE(p.has_value());
 }
 
@@ -46,7 +48,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p = utils::LifetimeTracker::Session(&tracker);
+    pro::proxy<details::TestFacade> p = utils::LifetimeTracker::Session(&tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 2");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
@@ -67,7 +69,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_FromValue_Exception) {
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
-      pro::proxy<TestFacade> p = another_session;
+      pro::proxy<details::TestFacade> p = another_session;
     } catch (const utils::ConstructionFailure& e) {
       exception_thrown = true;
       ASSERT_EQ(e.type_, utils::LifetimeOperationType::kCopyConstruction);
@@ -83,7 +85,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlace) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
@@ -100,7 +102,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlace_Exception) {
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
-      pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+      pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     } catch (const utils::ConstructionFailure& e) {
       exception_thrown = true;
       ASSERT_EQ(e.type_, utils::LifetimeOperationType::kValueConstruction);
@@ -115,7 +117,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlaceInitializerList) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, { 1, 2, 3 }, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, { 1, 2, 3 }, &tracker };
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kInitializerListConstruction);
@@ -132,7 +134,7 @@ TEST(ProxyLifetimeTests, TestPolyConstrction_InPlaceInitializerList_Exception) {
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
-      pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, { 1, 2, 3 }, &tracker };
+      pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, { 1, 2, 3 }, &tracker };
     } catch (const utils::ConstructionFailure& e) {
       exception_thrown = true;
       ASSERT_EQ(e.type_, utils::LifetimeOperationType::kInitializerListConstruction);
@@ -147,7 +149,7 @@ TEST(ProxyLifetimeTests, TestCopyConstrction_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
@@ -166,7 +168,7 @@ TEST(ProxyLifetimeTests, TestCopyConstrction_FromValue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -186,7 +188,7 @@ TEST(ProxyLifetimeTests, TestCopyConstrction_FromValue_Exception) {
 }
 
 TEST(ProxyLifetimeTests, TestCopyConstrction_FromNull) {
-  pro::proxy<TestFacade> p1;
+  pro::proxy<details::TestFacade> p1;
   auto p2 = p1;
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
@@ -196,7 +198,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
@@ -216,7 +218,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromValue_Trivial) {
   {
     utils::LifetimeTracker::Session session{ &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestTrivialFacade> p1 = &session;
+    pro::proxy<details::TestTrivialFacade> p1 = &session;
     ASSERT_TRUE(p1.has_value());
     auto p2 = std::move(p1);
     ASSERT_TRUE(p1.has_value());
@@ -229,7 +231,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromValue_Trivial) {
 }
 
 TEST(ProxyLifetimeTests, TestMoveConstrction_FromNull) {
-  pro::proxy<TestFacade> p1;
+  pro::proxy<details::TestFacade> p1;
   auto p2 = std::move(p1);
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
@@ -239,7 +241,7 @@ TEST(ProxyLifetimeTests, TestNullAssignment_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p = nullptr;
     ASSERT_FALSE(p.has_value());
@@ -250,7 +252,7 @@ TEST(ProxyLifetimeTests, TestNullAssignment_ToValue) {
 }
 
 TEST(ProxyLifetimeTests, TestNullAssignment_ToNull) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
   p = nullptr;
   ASSERT_FALSE(p.has_value());
 }
@@ -259,7 +261,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
@@ -280,7 +282,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_ToValue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     utils::LifetimeTracker::Session session{ &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
@@ -306,7 +308,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_FromValue_ToNull) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     p = utils::LifetimeTracker::Session{ &tracker };
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 3");
@@ -327,7 +329,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_FromValue_ToNull_Exception) {
   {
     utils::LifetimeTracker::Session session{ &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
@@ -348,7 +350,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
@@ -365,7 +367,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToValue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -387,7 +389,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToNull) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
@@ -402,7 +404,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlace_ToNull_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
@@ -422,7 +424,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p.emplace<utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
@@ -439,7 +441,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToValue_Excep
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -461,7 +463,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToNull) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     p.emplace<utils::LifetimeTracker::Session>({ 1, 2, 3 }, &tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
@@ -476,7 +478,7 @@ TEST(ProxyLifetimeTests, TestPolyAssignment_InPlaceInitializerList_ToNull_Except
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
     try {
@@ -496,9 +498,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     p1 = p2;
     ASSERT_TRUE(p1.has_value());
@@ -520,9 +522,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToValue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -548,7 +550,7 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToSelf) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -570,8 +572,8 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToNull) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1;
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1;
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p1 = p2;
     ASSERT_TRUE(p1.has_value());
@@ -592,8 +594,8 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromValue_ToNull_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1;
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1;
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -617,9 +619,9 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromNull_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2;
+    pro::proxy<details::TestFacade> p2;
     p1 = p2;
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -628,7 +630,7 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromNull_ToValue) {
 }
 
 TEST(ProxyLifetimeTests, TestCopyAssignment_FromNull_ToSelf) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
@@ -641,8 +643,8 @@ TEST(ProxyLifetimeTests, TestCopyAssignment_FromNull_ToSelf) {
 }
 
 TEST(ProxyLifetimeTests, TestCopyAssignment_FromNull_ToNull) {
-  pro::proxy<TestFacade> p1;
-  pro::proxy<TestFacade> p2;
+  pro::proxy<details::TestFacade> p1;
+  pro::proxy<details::TestFacade> p2;
   p1 = p2;
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
@@ -652,9 +654,9 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     p1 = std::move(p2);
     ASSERT_TRUE(p1.has_value());
@@ -673,9 +675,9 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToValue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -699,7 +701,7 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToSelf) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -725,8 +727,8 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToNull) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1;
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1;
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p1 = std::move(p2);
     ASSERT_TRUE(p1.has_value());
@@ -744,8 +746,8 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromValue_ToNull_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1;
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1;
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -768,9 +770,9 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2;
+    pro::proxy<details::TestFacade> p2;
     p1 = std::move(p2);
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -779,7 +781,7 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToValue) {
 }
 
 TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToSelf) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
@@ -797,8 +799,8 @@ TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToSelf) {
 }
 
 TEST(ProxyLifetimeTests, TestMoveAssignment_FromNull_ToNull) {
-  pro::proxy<TestFacade> p1;
-  pro::proxy<TestFacade> p2;
+  pro::proxy<details::TestFacade> p1;
+  pro::proxy<details::TestFacade> p2;
   p1 = std::move(p2);
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
@@ -808,7 +810,7 @@ TEST(ProxyLifetimeTests, TestHasValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     ASSERT_FALSE(p.has_value());
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
@@ -822,12 +824,12 @@ TEST(ProxyLifetimeTests, TestHasValue) {
 
 TEST(ProxyLifetimeTests, TestOperatorBool) {
   // Implicit conversion to bool shall be prohibited.
-  static_assert(!std::is_nothrow_convertible_v<pro::proxy<TestFacade>, bool>);
+  static_assert(!std::is_nothrow_convertible_v<pro::proxy<details::TestFacade>, bool>);
 
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     ASSERT_FALSE(static_cast<bool>(p));
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(static_cast<bool>(p));
@@ -843,7 +845,7 @@ TEST(ProxyLifetimeTests, TestEqualsToNullptr) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p;
+    pro::proxy<details::TestFacade> p;
     ASSERT_TRUE(p == nullptr);
     ASSERT_TRUE(nullptr == p);
     p.emplace<utils::LifetimeTracker::Session>(&tracker);
@@ -861,7 +863,7 @@ TEST(ProxyLifetimeTests, TestReset_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     p.reset();
     ASSERT_FALSE(p.has_value());
@@ -872,7 +874,7 @@ TEST(ProxyLifetimeTests, TestReset_FromValue) {
 }
 
 TEST(ProxyLifetimeTests, TestReset_FromNull) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
   p.reset();
   ASSERT_FALSE(p.has_value());
 }
@@ -881,9 +883,9 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Value) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(2, utils::LifetimeOperationType::kValueConstruction);
     swap(p1, p2);
     ASSERT_TRUE(p1.has_value());
@@ -907,7 +909,7 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Self) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     swap(p, p);
     ASSERT_TRUE(p.has_value());
@@ -926,9 +928,9 @@ TEST(ProxyLifetimeTests, TestSwap_Value_Null) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2;
+    pro::proxy<details::TestFacade> p2;
     swap(p1, p2);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
@@ -944,8 +946,8 @@ TEST(ProxyLifetimeTests, TestSwap_Null_Value) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p1;
-    pro::proxy<TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p1;
+    pro::proxy<details::TestFacade> p2{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     swap(p1, p2);
     ASSERT_TRUE(p1.has_value());
@@ -959,14 +961,14 @@ TEST(ProxyLifetimeTests, TestSwap_Null_Value) {
 }
 
 TEST(ProxyLifetimeTests, TestSwap_Null_Self) {
-  pro::proxy<TestFacade> p;
+  pro::proxy<details::TestFacade> p;
   swap(p, p);
   ASSERT_FALSE(p.has_value());
 }
 
 TEST(ProxyLifetimeTests, TestSwap_Null_Null) {
-  pro::proxy<TestFacade> p1;
-  pro::proxy<TestFacade> p2;
+  pro::proxy<details::TestFacade> p1;
+  pro::proxy<details::TestFacade> p2;
   swap(p1, p2);
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
@@ -976,7 +978,7 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Lvalue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto session = utils::LifetimeTracker::Session{p};
     ASSERT_TRUE(p.has_value());
@@ -994,7 +996,7 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Rvalue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     auto session = utils::LifetimeTracker::Session{std::move(p)};
     ASSERT_FALSE(p.has_value());
@@ -1011,7 +1013,7 @@ TEST(ProxyLifetimeTests, Test_DirectConvension_Rvalue_Exception) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestFacade> p{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
     tracker.ThrowOnNextConstruction();
     bool exception_thrown = false;
@@ -1033,9 +1035,9 @@ TEST(ProxyLifetimeTests, Test_UpwardCopyConvension_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestRttiFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestRttiFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2 = p1;
+    pro::proxy<details::TestFacade> p2 = p1;
     ASSERT_TRUE(p1.has_value());
     ASSERT_EQ(ToString(*p1), "Session 1");
     ASSERT_STREQ(p1.GetTypeName(), typeid(utils::LifetimeTracker::Session).name());
@@ -1050,8 +1052,8 @@ TEST(ProxyLifetimeTests, Test_UpwardCopyConvension_FromValue) {
 }
 
 TEST(ProxyLifetimeTests, Test_UpwardCopyConvension_FromNull) {
-  pro::proxy<TestRttiFacade> p1;
-  pro::proxy<TestFacade> p2 = p1;
+  pro::proxy<details::TestRttiFacade> p1;
+  pro::proxy<details::TestFacade> p2 = p1;
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
 }
@@ -1060,9 +1062,9 @@ TEST(ProxyLifetimeTests, Test_UpwardMoveConvension_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
-    pro::proxy<TestRttiFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
+    pro::proxy<details::TestRttiFacade> p1{ std::in_place_type<utils::LifetimeTracker::Session>, &tracker };
     expected_ops.emplace_back(1, utils::LifetimeOperationType::kValueConstruction);
-    pro::proxy<TestFacade> p2 = std::move(p1);
+    pro::proxy<details::TestFacade> p2 = std::move(p1);
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 2");
@@ -1075,8 +1077,8 @@ TEST(ProxyLifetimeTests, Test_UpwardMoveConvension_FromValue) {
 }
 
 TEST(ProxyLifetimeTests, Test_UpwardMoveConvension_FromNull) {
-  pro::proxy<TestRttiFacade> p1;
-  pro::proxy<TestFacade> p2 = std::move(p1);
+  pro::proxy<details::TestRttiFacade> p1;
+  pro::proxy<details::TestFacade> p2 = std::move(p1);
   ASSERT_FALSE(p1.has_value());
   ASSERT_FALSE(p2.has_value());
 }

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -7,7 +7,7 @@
 #include "proxy.h"
 #include "utils.h"
 
-namespace {
+namespace proxy_reflection_tests_details {
 
 struct TraitsReflector {
  public:
@@ -42,24 +42,26 @@ struct TestTraitsFacade : pro::facade_builder
     ::add_direct_reflection<TraitsReflector>
     ::build {};
 
-}  // namespace
+}  // namespace proxy_reflection_tests_details
+
+namespace details = proxy_reflection_tests_details;
 
 TEST(ProxyReflectionTests, TestRtti_RawPtr) {
   int foo = 123;
-  pro::proxy<TestRttiFacade> p = &foo;
+  pro::proxy<details::TestRttiFacade> p = &foo;
   ASSERT_STREQ(p.GetTypeName(), typeid(int*).name());
   ASSERT_STREQ(p->GetTypeName(), typeid(int).name());
 }
 
 TEST(ProxyReflectionTests, TestRtti_FancyPtr) {
-  pro::proxy<TestRttiFacade> p = std::make_unique<double>(1.23);
+  pro::proxy<details::TestRttiFacade> p = std::make_unique<double>(1.23);
   ASSERT_STREQ(p.GetTypeName(), typeid(std::unique_ptr<double>).name());
   ASSERT_STREQ(p->GetTypeName(), typeid(double).name());
 }
 
 TEST(ProxyReflectionTests, TestTraits_RawPtr) {
   int foo = 123;
-  pro::proxy<TestTraitsFacade> p = &foo;
+  pro::proxy<details::TestTraitsFacade> p = &foo;
   ASSERT_EQ(p.ReflectTraits().is_default_constructible_, true);
   ASSERT_EQ(p.ReflectTraits().is_copy_constructible_, true);
   ASSERT_EQ(p.ReflectTraits().is_nothrow_move_constructible_, true);
@@ -68,7 +70,7 @@ TEST(ProxyReflectionTests, TestTraits_RawPtr) {
 }
 
 TEST(ProxyReflectionTests, TestTraits_FancyPtr) {
-  pro::proxy<TestTraitsFacade> p = std::make_unique<double>(1.23);
+  pro::proxy<details::TestTraitsFacade> p = std::make_unique<double>(1.23);
   ASSERT_EQ(p.ReflectTraits().is_default_constructible_, true);
   ASSERT_EQ(p.ReflectTraits().is_copy_constructible_, false);
   ASSERT_EQ(p.ReflectTraits().is_nothrow_move_constructible_, true);

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -7,7 +7,7 @@
 #include "proxy.h"
 #include "utils.h"
 
-namespace {
+namespace proxy_traits_tests_details {
 
 template <bool kNothrowRelocatable, bool kCopyable, bool kTrivial, std::size_t kSize, std::size_t kAlignment>
 struct MockPtr {
@@ -352,4 +352,4 @@ static_assert(pro::facade<FacadeWithSizeOfNonPowerOfTwo>);
 static_assert(FacadeWithSizeOfNonPowerOfTwo::constraints.max_size == 6u);
 static_assert(FacadeWithSizeOfNonPowerOfTwo::constraints.max_align == 2u);
 
-}  // namespace
+}  // namespace proxy_traits_tests_details

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -196,12 +196,6 @@ static_assert(pro::facade<FacadeWithTupleLikeConventions>);
 
 struct BadFacade_MissingConventionTypes {
   using reflection_types = std::tuple<>;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-const-variable"
-#elif defined(__NVCOMPILER)
-#pragma diag_suppress declared_but_not_referenced
-#endif  // __clang__
   static constexpr auto constraints = pro::proxiable_ptr_constraints{
       .max_size = 2 * sizeof(void*),
       .max_align = alignof(void*),
@@ -209,21 +203,12 @@ struct BadFacade_MissingConventionTypes {
       .relocatability = pro::constraint_level::nothrow,
       .destructibility = pro::constraint_level::nothrow,
   };
-#ifdef __clang__
-#pragma clang diagnostic pop
-#elif defined(__NVCOMPILER)
-#pragma diag_default declared_but_not_referenced
-#endif  // __clang__
 };
 static_assert(!pro::facade<BadFacade_MissingConventionTypes>);
 
 struct BadFacade_BadConventionTypes {
   using convention_types = int;
   using reflection_types = std::tuple<>;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-const-variable"
-#endif  // __clang__
   static constexpr auto constraints = pro::proxiable_ptr_constraints{
       .max_size = 2 * sizeof(void*),
       .max_align = alignof(void*),
@@ -231,9 +216,6 @@ struct BadFacade_BadConventionTypes {
       .relocatability = pro::constraint_level::nothrow,
       .destructibility = pro::constraint_level::nothrow,
   };
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif  // __clang__
 };
 static_assert(!pro::facade<BadFacade_BadConventionTypes>);
 
@@ -246,13 +228,7 @@ static_assert(!pro::facade<BadFacade_MissingConstraints>);
 struct BadFacade_BadConstraints_UnexpectedType {
   using convention_types = std::tuple<>;
   using reflection_types = std::tuple<>;
-#ifdef __NVCOMPILER
-#pragma diag_suppress declared_but_not_referenced
-#endif  // __NVCOMPILER
   static constexpr auto constraints = 0;
-#ifdef __NVCOMPILER
-#pragma diag_default declared_but_not_referenced
-#endif  // __NVCOMPILER
 };
 static_assert(!pro::facade<BadFacade_BadConstraints_UnexpectedType>);
 
@@ -298,12 +274,6 @@ const pro::proxiable_ptr_constraints BadFacade_BadConstraints_NotConstant::const
 
 struct BadFacade_MissingReflectionTypes {
   using convention_types = std::tuple<>;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-const-variable"
-#elif defined(__NVCOMPILER)
-#pragma diag_suppress declared_but_not_referenced
-#endif  // __clang__
   static constexpr auto constraints = pro::proxiable_ptr_constraints{
       .max_size = 2 * sizeof(void*),
       .max_align = alignof(void*),
@@ -311,11 +281,6 @@ struct BadFacade_MissingReflectionTypes {
       .relocatability = pro::constraint_level::nothrow,
       .destructibility = pro::constraint_level::nothrow,
   };
-#ifdef __clang__
-#pragma clang diagnostic pop
-#elif defined(__NVCOMPILER)
-#pragma diag_default declared_but_not_referenced
-#endif  // __clang__
 };
 static_assert(!pro::facade<BadFacade_MissingReflectionTypes>);
 


### PR DESCRIPTION
**Motivation**

Member functions of `proxy` cannot be called from a debugger, making it difficult to debug with a value of `proxy` from client code.

**Changes**

- Added a helper type `details::symbol_guard` to guide symbol generation in a debug build (when `NODEBUG` is not defined).
- Enabled symbol generation for `proxy::operator->` and `proxy::operator*`.
- Enabled symbol generation for all the pre-defined dispatch types and macros that generates member functions, including `operator_dispatch`, `conversion_dispatch`, `PRO_DEF_MEM_DISPATCH`, `PRO_DEF_FREE_AS_MEM_DISPATCH` and the dispatch type generated for `basic_facade_builder::add_facade<F, true>`.
- Refactored the implementation of `proxy` accordingly to ensure template instantiation happens at the right spots.
- Moved some types out of an anonymous namespace in unit tests to avoid generating warnings of unused variables in a debug build.
- Removed some warning suppressions in unit tests accordingly.

**Verification**

Build the following code with MSVC in debug mode (without using the value of `proxy` in the code):

```cpp
#include <string>

#include "proxy.h"

PRO_DEF_FREE_AS_MEM_DISPATCH(MemToString, std::to_string, ToString);

struct Stringable : pro::facade_builder
  ::add_convention<MemToString, std::string() const>
  ::build {};

int main() {
  int v = 123;
  pro::proxy<Stringable> p = &v;
}
```

Set a breakpoint at the end of `main` and inspect the value of `p` in the debugger. The debugger invokes the correct function for me.

![image](https://github.com/user-attachments/assets/06ed7f79-6b00-46ce-b77d-e525c9f85bb3)
