### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -36,6 +36,8 @@ jobs:
 
   draft-release:
     name: Draft release
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     needs: report
     steps:


### PR DESCRIPTION
Because the default permissions for GitHub workflows in Microsoft org were set to "read-only", "git push" will be blocked.