### PR TITLE
Improve the release pipeline

### DIFF
--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -23,5 +23,5 @@ jobs:
         draft: true
         tag_name: ${{ steps.run_pack.outputs.PRO_VER }}
         files: proxy-*.tgz
-        name: Proxy Release
+        name: Proxy ${{ steps.run_pack.outputs.PRO_VER }} Release
         generate_release_notes: true

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -14,8 +14,13 @@ jobs:
     - name: pack source
       id: run_pack
       run: |
-        chmod 555 ./tools/pack.sh
-        ./tools/pack.sh
+        file="CMakeLists.txt"
+        version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
+        git tag "$version"
+        git push origin "$version"
+        tar -czf "proxy-$version.tgz" "proxy.h"
+        echo "PRO_VER=$version" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: create release draft
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: pack source
-      id: run_pack
+      id: run-pack
       run: |
         file="CMakeLists.txt"
         version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
@@ -26,7 +26,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         draft: true
-        tag_name: ${{ steps.run_pack.outputs.PRO_VER }}
+        tag_name: ${{ steps.run-pack.outputs.PRO_VER }}
         files: proxy-*.tgz
-        name: Proxy ${{ steps.run_pack.outputs.PRO_VER }} Release
+        name: Proxy ${{ steps.run-pack.outputs.PRO_VER }} Release
         generate_release_notes: true

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: pack and tag
+    - name: pack source
+      id: run_pack
       run: |
         chmod 555 ./tools/pack.sh
         ./tools/pack.sh
@@ -20,6 +21,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         draft: true
+        tag: ${{ steps.run_pack.outputs.PRO_VER }}
         files: proxy-*.tgz
         name: Proxy Release
         generate_release_notes: true

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -21,7 +21,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         draft: true
-        tag: ${{ steps.run_pack.outputs.PRO_VER }}
+        tag_name: ${{ steps.run_pack.outputs.PRO_VER }}
         files: proxy-*.tgz
         name: Proxy Release
         generate_release_notes: true

--- a/.github/workflows/pipeline-release.yml
+++ b/.github/workflows/pipeline-release.yml
@@ -2,66 +2,24 @@ name: Proxy-Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version: 
-        description: 'Release version (x.x.x)'
-        required: true
-        default: '0.0.0'
 
 jobs:
-  run-bvt-gcc:
-    name: Run BVT with GCC
-    uses: ./.github/workflows/bvt-gcc.yml
-
-  run-bvt-clang:
-    name: Run BVT with Clang
-    uses: ./.github/workflows/bvt-clang.yml
-
-  run-bvt-msvc:
-    name: Run BVT with MSVC
-    uses: ./.github/workflows/bvt-msvc.yml
-
-  run-bvt-appleclang:
-    name: Run BVT with AppleClang
-    uses: ./.github/workflows/bvt-appleclang.yml
-
-  run-bvt-nvhpc:
-    name: Run BVT with NVHPC
-    uses: ./.github/workflows/bvt-nvhpc.yml
-
-  report:
-    uses: ./.github/workflows/bvt-report.yml
-    name: Generate report
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc]
-
   draft-release:
     name: Draft release
     permissions:
       contents: write
     runs-on: ubuntu-24.04
-    needs: report
     steps:
     - uses: actions/checkout@v4
-
-    - name: create tag
+    - name: pack and tag
       run: |
-        git checkout -b release/${{ github.event.inputs.version }}
-        sed -i 's/VERSION 0\.1\.0 # local build version/VERSION ${{ github.event.inputs.version }}/' CMakeLists.txt
-        git config --local user.email "release-bot@no.email.com"
-        git config --local user.name "release bot"
-        git add CMakeLists.txt
-        git commit -m "Release version ${{ github.event.inputs.version }}"
-        git tag ${{ github.event.inputs.version }}
-        git push origin ${{ github.event.inputs.version }}
-
-    - name: create tgz archive
-      run: tar -czf "proxy-${{ github.event.inputs.version }}.tgz" "proxy.h"
+        chmod 555 ./tools/pack.sh
+        ./tools/pack.sh
 
     - name: create release draft
       uses: softprops/action-gh-release@v2
       with:
         draft: true
-        files: proxy-${{ github.event.inputs.version }}.tgz
-        name: Proxy ${{ github.event.inputs.version }} Release
-        tag_name: ${{ github.event.inputs.version }}
+        files: proxy-*.tgz
+        name: Proxy Release
         generate_release_notes: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(msft_proxy
-        VERSION 0.1.0 # local build version
-        LANGUAGES CXX)
+project(msft_proxy VERSION 0.1.0 LANGUAGES CXX)
 add_library(msft_proxy INTERFACE)
 target_compile_features(msft_proxy INTERFACE cxx_std_20)
 target_include_directories(msft_proxy INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-file="CMakeLists.txt"
-version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
-git tag "$version"
-git push origin "$version"
-tar -czf "proxy-$version.tgz" "proxy.h"
-echo "PRO_VER=$version" >> $GITHUB_OUTPUT

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+file="CMakeLists.txt"
+version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
+git tag "$version"
+git push origin "$version"
+tar -czf "proxy-$version.tgz" "proxy.h"

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -4,4 +4,4 @@ version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
 git tag "$version"
 git push origin "$version"
 tar -czf "proxy-$version.tgz" "proxy.h"
-echo "PRO_VER=$version\n" >> $GITHUB_OUTPUT
+echo "PRO_VER=$version" >> $GITHUB_OUTPUT

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -4,3 +4,4 @@ version=$(grep -oP 'msft_proxy\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' "$file")
 git tag "$version"
 git push origin "$version"
 tar -czf "proxy-$version.tgz" "proxy.h"
+echo "PRO_VER=$version\n" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What
The tags submitted by the release pipeline are not associated to any branch because the commits were created on a local branch on pipeline agent which didn't go to the remote. This PR changes the way we manage our release versions. The changes are:
1. The new release pipeline extract version number from the `CMakeList.txt` file.
2. The new release pipeline assumes that all validations are passed over the latest commit of the main branch. Therefore, the pipeline is no longer run validations to save time and cost.
3. The new release pipeline requires a separated PR to bump the version number in the main branch.

## Test
Sample pipeline results can be found at: https://github.com/tian-lt/proxy/releases and https://github.com/tian-lt/proxy/tags