### PR TITLE
Fix the `std::in_place_type_t` overload for SFINAE-unsafe facades

### DIFF
--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -15,20 +15,13 @@ jobs:
 
     - name: install clang
       run: |
-        sudo apt install -y clang-15 clang-16 clang-17 clang-18
+        sudo apt install -y clang-16 clang-17 clang-18
 
     - name: check compiler versions
       run: |
-        clang++-15 --version
         clang++-16 --version
         clang++-17 --version
         clang++-18 --version
-
-    - name: build and run test with clang 15
-      run: |
-        cmake -B build-clang-15 -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_BUILD_TYPE=Release
-        cmake --build build-clang-15 -j
-        ctest --test-dir build-clang-15 -j
 
     - name: build and run test with clang 16
       run: |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The "Proxy" library is a self-contained solution for runtime polymorphism in C++
 | Family     | Minimum version | Required flags |
 | ---------- | --------------- | -------------- |
 | GCC        | 13.1            | -std=c++20     |
-| Clang      | 15.0.0          | -std=c++20     |
+| Clang      | 16.0.0          | -std=c++20     |
 | MSVC       | 19.31           | /std:c++20     |
 | NVIDIA HPC | 24.1            | -std=c++20     |
 

--- a/proxy.h
+++ b/proxy.h
@@ -1265,8 +1265,6 @@ template <class F, class C>
 using adl_accessor_arg_t =
     std::conditional_t<C::is_direct, proxy<F>, proxy_indirect_accessor<F>>;
 
-template <class O>
-using overload_return_type = typename overload_traits<O>::return_type;
 #define ___PRO_DEF_CAST_ACCESSOR(Q, SELF, ...) \
     template <class __F, class __C, class T> \
     struct accessor<__F, __C, T() Q> { \

--- a/proxy.h
+++ b/proxy.h
@@ -1281,7 +1281,7 @@ using overload_return_type = typename overload_traits<O>::return_type;
 template <bool Expl, bool Nullable>
 struct cast_dispatch_base {
   ___PRO_DEF_MEM_ACCESSOR_TEMPLATE(___PRO_DEF_CAST_ACCESSOR,
-      operator overload_return_type<__Os>)
+      operator typename overload_traits<__Os>::return_type)
 };
 #undef ___PRO_DEF_CAST_ACCESSOR
 


### PR DESCRIPTION
This change explicitly excludes `proxy(P&& ptr)` from overload resolution if `P` is a (possibly cv-qualified) specialization of `std::in_place_type_t`. It aligns with the implementation of `std::any` in [MSVC](https://github.com/microsoft/STL/blob/90820002693fe6eaaec2e55884472c654186207e/stl/inc/any#L134) and [libstdc++](https://github.com/gcc-mirror/gcc/blob/71732eafedbd30355e752bf873d355fbcd0e076f/libstdc++-v3/include/std/any#L195).

Note that Clang 15 could not handle the situation where concepts are mixed with SFINAE. The test case will still fail in Clang 15. Since it is not trivial to work around, I removed support for Clang 15 from our pipeline and README for now. (See [the previous CI build](https://github.com/microsoft/proxy/actions/runs/12427335254)).

Resolves #222. Another unit test case was added accordingly.