### PR TITLE
Replace macro `PRO_DEF_WEAK_DISPATCH` with class template `weak_dispatch`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -1994,7 +1994,7 @@ template <class D>
 struct weak_dispatch : D {
   using D::operator();
   template <class... Args>
-  details::wildcard operator()(std::nullptr_t, Args&&...)
+  [[noreturn]] details::wildcard operator()(std::nullptr_t, Args&&...)
       { ___PRO_THROW(not_implemented{}); }
 };
 

--- a/proxy.h
+++ b/proxy.h
@@ -9,10 +9,10 @@
 #include <cstdlib>
 #include <bit>
 #include <concepts>
+#include <exception>
 #include <initializer_list>
 #include <limits>
 #include <memory>
-#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -1264,7 +1264,7 @@ using proxy_view = proxy<observer_facade<F>>;
 class bad_proxy_cast : public std::bad_cast {
  public:
   bad_proxy_cast() noexcept = default;
-  char const* what() const final { return "pro::bad_proxy_cast"; }
+  char const* what() const noexcept final { return "pro::bad_proxy_cast"; }
 };
 #endif  // __cpp_rtti
 
@@ -1984,9 +1984,10 @@ struct explicit_conversion_dispatch : details::cast_dispatch_base<true, false> {
 };
 using conversion_dispatch = explicit_conversion_dispatch;
 
-class not_implemented : public std::logic_error {
+class not_implemented : public std::exception {
  public:
-  not_implemented() : logic_error("pro::not_implemented") {}
+  not_implemented() noexcept = default;
+  char const* what() const noexcept final { return "pro::not_implemented"; }
 };
 
 template <class D>
@@ -2076,9 +2077,9 @@ ___PRO_DEBUG( \
 #define PRO_DEF_FREE_AS_MEM_DISPATCH(__NAME, ...) \
     ___PRO_EXPAND_MACRO(___PRO_DEF_FREE_AS_MEM_DISPATCH, __NAME, __VA_ARGS__)
 
-// PRO_DEF_WEAK_DISPATCH has been deprecated since version 3.2.0
 #define PRO_DEF_WEAK_DISPATCH(__NAME, __D, __FUNC) \
-    struct [[deprecated("Use pro::weak_dispatch instead")]] __NAME : __D { \
+    struct [[deprecated("'PRO_DEF_WEAK_DISPATCH' is deprecated. " \
+        "Use pro::weak_dispatch<" #__D "> instead.")]] __NAME : __D { \
       using __D::operator(); \
       template <class... __Args> \
       decltype(auto) operator()(::std::nullptr_t, __Args&&... __args) \

--- a/proxy.h
+++ b/proxy.h
@@ -1264,7 +1264,7 @@ using proxy_view = proxy<observer_facade<F>>;
 class bad_proxy_cast : public std::bad_cast {
  public:
   bad_proxy_cast() noexcept = default;
-  char const* what() const noexcept final { return "pro::bad_proxy_cast"; }
+  char const* what() const noexcept override { return "pro::bad_proxy_cast"; }
 };
 #endif  // __cpp_rtti
 
@@ -1987,7 +1987,7 @@ using conversion_dispatch = explicit_conversion_dispatch;
 class not_implemented : public std::exception {
  public:
   not_implemented() noexcept = default;
-  char const* what() const noexcept final { return "pro::not_implemented"; }
+  char const* what() const noexcept override { return "pro::not_implemented"; }
 };
 
 template <class D>

--- a/tests/freestanding/proxy_freestanding_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "proxy.h"
 
+constexpr unsigned DefaultHash = -1;
 unsigned GetHash(int v) { return static_cast<unsigned>(v + 3) * 31; }
 unsigned GetHash(double v) { return static_cast<unsigned>(v * v + 5) * 87; }
 unsigned GetHash(const char* v) {
@@ -13,12 +14,11 @@ unsigned GetHash(const char* v) {
   }
   return result;
 }
-unsigned GetDefaultHash() { return -1; }
+unsigned GetHash(std::nullptr_t) { return DefaultHash; }
 
 PRO_DEF_FREE_DISPATCH(FreeGetHash, GetHash);
-PRO_DEF_WEAK_DISPATCH(WeakFreeGetHash, FreeGetHash, GetDefaultHash);
 struct Hashable : pro::facade_builder
-    ::add_convention<WeakFreeGetHash, unsigned()>
+    ::add_convention<FreeGetHash, unsigned()>
     ::build {};
 
 extern "C" int main() {
@@ -40,7 +40,7 @@ extern "C" int main() {
     return 1;
   }
   p = &t;
-  if (GetHash(*p) != GetDefaultHash()) {
+  if (GetHash(*p) != DefaultHash) {
     return 1;
   }
   return 0;

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -36,18 +36,10 @@ struct Callable : pro::facade_builder
     ::add_facade<MovableCallable<Os...>>
     ::build {};
 
-struct Wildcard {
-  template <class T>
-  operator T() const noexcept { std::terminate(); }
-};
-
-Wildcard NotImplemented(auto&&...) { throw std::runtime_error{ "Not implemented!" }; }
-
-PRO_DEF_WEAK_DISPATCH(WeakOpCall, pro::operator_dispatch<"()">, NotImplemented);
 template <class... Os>
 struct WeakCallable : pro::facade_builder
     ::support_copy<pro::constraint_level::nontrivial>
-    ::add_convention<WeakOpCall, Os...>
+    ::add_convention<pro::weak_dispatch<pro::operator_dispatch<"()">>, Os...>
     ::build {};
 
 PRO_DEF_FREE_DISPATCH(FreeSize, std::ranges::size, Size);
@@ -77,10 +69,9 @@ struct Container : pro::facade_builder
     ::build {};
 
 PRO_DEF_MEM_DISPATCH(MemAt, at, at);
-PRO_DEF_WEAK_DISPATCH(MemAtWeak, MemAt, NotImplemented);
 
 struct ResourceDictionary : pro::facade_builder
-    ::add_convention<MemAtWeak, std::string(int)>
+    ::add_convention<pro::weak_dispatch<MemAt>, std::string(int)>
     ::build {};
 
 template <class F, class T>
@@ -104,13 +95,11 @@ template <class F, class T>
 auto GetWeakImpl(const std::shared_ptr<T>& p) { return pro::make_proxy<Weak<F>, std::weak_ptr<T>>(p); }
 
 template <class F>
-PRO_DEF_FREE_DISPATCH(FreeGetWeakImpl, GetWeakImpl<F>, GetWeak);
-template <class F>
-PRO_DEF_WEAK_DISPATCH(FreeGetWeak, FreeGetWeakImpl<F>, std::nullptr_t);
+PRO_DEF_FREE_DISPATCH(FreeGetWeak, GetWeakImpl<F>, GetWeak);
 
 struct SharedStringable : pro::facade_builder
     ::add_facade<utils::spec::Stringable>
-    ::add_direct_convention<FreeGetWeak<SharedStringable>, pro::proxy<Weak<SharedStringable>>() const&>
+    ::add_direct_convention<pro::weak_dispatch<FreeGetWeak<SharedStringable>>, pro::proxy<Weak<SharedStringable>>() const&>
     ::build {};
 
 template <class F, bool NE, class... Args>
@@ -272,9 +261,8 @@ TEST(ProxyInvocationTests, TestMemberDispatchDefault) {
     bool exception_thrown = false;
     try {
       p->at(0);
-    } catch (const std::runtime_error& e) {
+    } catch (const pro::not_implemented&) {
       exception_thrown = true;
-      ASSERT_EQ(static_cast<std::string>(e.what()), "Not implemented!");
     }
     ASSERT_TRUE(exception_thrown);
   }
@@ -292,9 +280,8 @@ TEST(ProxyInvocationTests, TestFreeDispatchDefault) {
     auto p = pro::make_proxy<details::WeakCallable<void()>>(123);
     try {
       (*p)();
-    } catch (const std::runtime_error& e) {
+    } catch (const pro::not_implemented&) {
       exception_thrown = true;
-      ASSERT_EQ(static_cast<std::string>(e.what()), "Not implemented!");
     }
     ASSERT_TRUE(exception_thrown);
   }
@@ -313,7 +300,13 @@ TEST(ProxyInvocationTests, TestObserverDispatch) {
   p = &test_val;  // The underlying std::shared_ptr will be destroyed
   ASSERT_TRUE(weak.has_value());
   ASSERT_FALSE(Lock(*weak).has_value());
-  ASSERT_FALSE(GetWeak(p).has_value());
+  bool exception_thrown = false;
+  try {
+    GetWeak(p);
+  } catch (const pro::not_implemented&) {
+    exception_thrown = true;
+  }
+  ASSERT_TRUE(exception_thrown);
   ASSERT_EQ(ToString(*p), "123");
 }
 


### PR DESCRIPTION
This change replaced macro `PRO_DEF_WEAK_DISPATCH` with class template `weak_dispatch<D>`. Specifically,

- Added a new exception type `not_implemented`, inspired by [NotImplementedException in .NET](https://stackoverflow.com/questions/24469927/does-c-have-an-equivalent-to-nets-notimplementedexception). However, `not_implemented` is not derived from `std::logic_error` or `std::runtime_error` due to freestanding limitations.
- `weak_dispatch<D>` will add a default implementation to an existing dispatch type `D`. The default implementation simply throws `not_implemented`.
- Updated unit tests accordingly.
- Added `[[deprecated]]` attribute to types defined with `PRO_DEF_WEAK_DISPATCH`.
- Added error message to `bad_proxy_cast`.
- Documentation and sample code will be updated later.

Note that the return type of `weak_dispatch`'s default implementation is `details::wildcard`, which can syntactically be convertible to any type, while it will never be constructed.