### PR TITLE
Simplify `proxy_invoke` and `proxy_reflect`

### DIFF
--- a/docs/PRO_DEF_FREE_AS_MEM_DISPATCH.md
+++ b/docs/PRO_DEF_FREE_AS_MEM_DISPATCH.md
@@ -16,7 +16,7 @@ PRO_DEF_FREE_AS_MEM_DISPATCH(dispatch_name, func_name, accessibility_func_name);
 
 `(1)` Equivalent to `PRO_DEF_FREE_AS_MEM_DISPATCH(dispatch_name, func_name, func_name);`
 
-`(2)` Defines a class named `dispatch_name` of free function call expressions of `func_name` with accessibility via a member function. `dispatch_name` meets the [*ProAccessible*](ProAccessible.md) requirements of types `F`, `C`, and `Os...`, where `F` models concept [`facade`](facade.md), `C` is a tuple element type defined in `typename F::convention_types`, and each type `O` (possibly qualified with *cv ref noex*) in `Os...` is a tuple element type defined in `typename C::overload_types`. The member functions provided by `typename dispatch_name::template accessor<F, C, Os...>` are named `accessibility_func_name`. Effectively equivalent to:
+`(2)` Defines a class named `dispatch_name` of free function call expressions of `func_name` with accessibility via member function overloads named `accessibility_func_name`. Effectively equivalent to:
 
 ```cpp
 struct dispatch_name {

--- a/docs/PRO_DEF_FREE_DISPATCH.md
+++ b/docs/PRO_DEF_FREE_DISPATCH.md
@@ -16,7 +16,7 @@ PRO_DEF_FREE_DISPATCH(dispatch_name, func_name, accessibility_func_name);
 
 `(1)` Equivalent to `PRO_DEF_FREE_DISPATCH(dispatch_name, func_name, func_name);`
 
-`(2)` Defines a class named `dispatch_name` of free function call expressions of `func_name` with accessibility. `dispatch_name` meets the [*ProAccessible*](ProAccessible.md) requirements of types `F`, `C`, and `Os...`, where `F` models concept [`facade`](facade.md), `C` is a tuple element type defined in `typename F::convention_types`, and each type `O` (possibly qualified with *cv ref noex*) in `Os...` is a tuple element type defined in `typename C::overload_types`. Let `accessor_arg` be `std::conditional_t<C::is_direct, proxy<F>, proxy_indirect_accessor<F>>`. The functions provided by `typename dispatch_name::template accessor<F, C, Os...>` are named `accessibility_func_name` and can be found by [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl) when `accessor_arg` is an associated class of the arguments. Effectively equivalent to:
+`(2)` Defines a class named `dispatch_name` of free function call expressions of `func_name` with accessibility via free function overloads named `accessibility_func_name`. Effectively equivalent to:
 
 ```cpp
 struct dispatch_name {
@@ -27,16 +27,17 @@ struct dispatch_name {
     return func_name(std::forward<T>(self), std::forward<Args>(args)...);
   }
 
-  template <class F, class C, class... Os> struct accessor {
+  template <class F, bool IsDirect, class D, class... Os>
+  struct accessor {
     accessor() = delete;
   };
-  template <class F, class C, class... Os>
-      requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, C, Os>> && ...))
-  struct accessor<F, C, Os...> : accessor<F, C, Os>... {};
-  template <class F, class C, class R, class... Args>
-  struct accessor<F, C, R(Args...) cv ref noex> {
+  template <class F, bool IsDirect, class D, class... Os>
+      requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, IsDirect, D, Os>> && ...))
+  struct accessor<F, IsDirect, D, Os...> : accessor<F, IsDirect, D, Os>... {};
+  template <class F, bool IsDirect, class D, class R, class... Args>
+  struct accessor<F, IsDirect, D, R(Args...) cv ref noex> {
     friend R accessibility_func_name(accessor_arg cv ref self, Args... args) noex {
-      return pro::proxy_invoke<C, R(Args...) cv ref noex>(pro::access_proxy<F>(std::forward<accessor_arg cv ref>(self)), std::forward<Args>(args)...);
+      return pro::proxy_invoke<IsDirect, D, R(Args...) cv ref noex>(pro::access_proxy<F>(std::forward<accessor_arg cv ref>(self)), std::forward<Args>(args)...);
     }
   };
 }

--- a/docs/ProAccessible.md
+++ b/docs/ProAccessible.md
@@ -1,10 +1,10 @@
 # Named requirements: *ProAccessible*
 
-Given that `F` is a type meeting the [*ProBasicFacade* requirements](ProBasicFacade.md), a type `T` meets the *ProAccessible* requirements of types `F, Args...`, if the following expressions are well-formed and have the specified semantics.
+Given that `F` is a type meeting the [*ProBasicFacade* requirements](ProBasicFacade.md), a type `T` meets the *ProAccessible* requirements of type `F`, if the following expressions are well-formed and have the specified semantics.
 
-| Expressions                                 | Semantics                                                    |
-| ------------------------------------------- | ------------------------------------------------------------ |
-| `typename T::template accessor<F, Args...>` | A type that provides accessibility to `proxy`. It shall be a *nothrow-default-constructible*, *trivially-copyable* type, and shall not be [final](https://en.cppreference.com/w/cpp/language/final). |
+| Expressions                        | Semantics                                                    |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `typename T::template accessor<F>` | A type that provides accessibility to `proxy`. It shall be a *nothrow-default-constructible*, *trivially-copyable* type, and shall not be [final](https://en.cppreference.com/w/cpp/language/final). |
 
 ## See Also
 

--- a/docs/access_proxy.md
+++ b/docs/access_proxy.md
@@ -48,14 +48,13 @@ int main() {
   std::cout << ToString(*p) << "\n";  // Prints: "123"
 
   // How it works behind the scenes
-  using Convention = std::tuple_element_t<0u, Stringable::convention_types>;
-  using Accessor = Convention::accessor<Stringable>;
+  using Accessor = FreeToString::accessor<Stringable, false, FreeToString, std::string()>;
   static_assert(std::is_base_of_v<Accessor, std::remove_reference_t<decltype(*p)>>);
   Accessor& a = static_cast<Accessor&>(*p);
   pro::proxy<Stringable>& p2 = pro::access_proxy<Stringable>(a);
   std::cout << std::boolalpha << (&p == &p2) << "\n";  // Prints: "true" because access_proxy converts
                                                        // an accessor back to the original proxy
-  auto result = pro::proxy_invoke<Convention, std::string()>(p2);
+  auto result = pro::proxy_invoke<false, FreeToString, std::string()>(p2);
   std::cout << result << "\n";  // Prints: "123"
 }
 ```

--- a/docs/basic_facade_builder/add_convention.md
+++ b/docs/basic_facade_builder/add_convention.md
@@ -18,12 +18,12 @@ The alias templates `add_convention`, `add_indirect_convention`, and `add_direct
   - `IC::is_direct` is `false`.
   - `typename IC::dispatch_type` is `D`.
   - `typename IC::overload_types` is a [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like) type of distinct types in `Os`.
-  - `typename IC::template accessor<F>` is `typename D::template accessor<F, IC, Os...>` if applicable.
+  - `typename IC::template accessor<F>` is `typename D::template accessor<F, false, D, Os...>` if applicable.
 - `add_direct_convention` merges an implementation-defined convention type `IC` into `Cs`, where:
   - `IC::is_direct` is `true`.
   - `typename IC::dispatch_type` is `D`.
   - `typename IC::overload_types` is a [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like) type of distinct types in `Os`.
-  - `typename IC::template accessor<F>` is `typename D::template accessor<F, IC, Os...>` if applicable.
+  - `typename IC::template accessor<F>` is `typename D::template accessor<F, true, D, Os...>` if applicable.
 
 When `Cs` already contains a convention type `IC2` where `IC2::is_direct == IC::is_direct && std::is_same_v<typename IC2::dispatch_type, typename IC::dispatch_type>` is `true`, `Os` merges with `typename IC2::overload_types` and removes duplicates, and `std::tuple_size_v<Cs>` shall not change.
 

--- a/docs/basic_facade_builder/add_reflection.md
+++ b/docs/basic_facade_builder/add_reflection.md
@@ -14,16 +14,16 @@ using add_direct_reflection = basic_facade_builder</* see below */>;
 The alias templates `add_reflection`, `add_indirect_reflection` and `add_direct_reflection` of `basic_facade_builder<Cs, Rs, C>` add reflection types to the template parameters. Specifically,
 
 - `add_reflection` is equivalent to `add_indirect_reflection`.
-- `add_indirect_reflection` merges an implementation-defined reflection type `R2` into `Rs`, where:
-  - `R2::is_direct` is `false`.
-  - `typename R2::reflector_type` is `R`.
-  - `typename R2::template accessor<F>` is `typename R2::template accessor<F, R2>` if applicable.
-- `add_direct_reflection` merges an implementation-defined reflection type `R2` into `Rs`, where:
-  - `R2::is_direct` is `true`.
-  - `typename R2::reflector_type` is `R`.
-  - `typename R2::template accessor<F>` is `typename R2::template accessor<F, R2>` if applicable.
+- `add_indirect_reflection` merges an implementation-defined reflection type `Refl` into `Rs`, where:
+  - `Refl::is_direct` is `false`.
+  - `typename Refl::reflector_type` is `R`.
+  - `typename Refl::template accessor<F>` is `typename R::template accessor<F, false, R>` if applicable.
+- `add_direct_reflection` merges an implementation-defined reflection type `Refl` into `Rs`, where:
+  - `Refl::is_direct` is `true`.
+  - `typename Refl::reflector_type` is `R`.
+  - `typename Refl::template accessor<F>` is `typename R::template accessor<F, true, R>` if applicable.
 
-When `Rs` already contains `R2`, the template parameters shall not change.
+When `Rs` already contains `Refl`, the template parameters shall not change.
 
 ## Notes
 
@@ -42,10 +42,10 @@ class RttiReflector {
   template <class T>
   constexpr explicit RttiReflector(std::in_place_type_t<T>) : type_(typeid(T)) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     const char* GetTypeName() const noexcept {
-      const RttiReflector& self = pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      const RttiReflector& self = pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
       return self.type_.name();
     }
   };

--- a/docs/explicit_conversion_dispatch/accessor.md
+++ b/docs/explicit_conversion_dispatch/accessor.md
@@ -2,27 +2,27 @@
 
 ```cpp
 // (1)
-template <class F, class C, class... Os>
+template <class F, bool IsDirect, class D, class... Os>
 struct accessor {
   accessor() = delete;
 };
 
 // (2)
-template <class F, class C, class... Os>
-    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, C, Os>> && ...))
-struct accessor<F, C, Os...> : accessor<F, C, Os>... {
-  using accessor<F, C, Os>::operator return-type-of<Os>...;
+template <class F, bool IsDirect, class D, class... Os>
+    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, IsDirect, D, Os>> && ...))
+struct accessor<F, IsDirect, D, Os...> : accessor<F, IsDirect, D, Os>... {
+  using accessor<F, IsDirect, D, Os>::operator return-type-of<Os>...;
 };
 
 // (3)
-template <class F, class C>
-struct accessor<F, C, T() cv ref noex> {
+template <class F, bool IsDirect, class D>
+struct accessor<F, IsDirect, D, T() cv ref noex> {
   explicit operator T() cv ref noex;
 };
 ```
 
 `(1)` The default implementation of `accessor` is not constructible.
 
-`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, C, Os>...` are default-constructible, inherits all `accessor<F, C, Os>...` types and `using` their `operator return-type-of<Os>`. `return-type-of<O>` denotes the *return type* of the overload type `O`.
+`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, IsDirect, D, Os>...` are default-constructible, inherits all `accessor<F, IsDirect, D, Os>...` types and `using` their `operator return-type-of<Os>`. `return-type-of<O>` denotes the *return type* of the overload type `O`.
 
-`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an explicit  `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<C, T() cv ref noex>(access_proxy<F>(std::forward<accessor cv ref>(*this)))`.
+`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an explicit  `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<IsDirect, D, T() cv ref noex>(access_proxy<F>(std::forward<accessor cv ref>(*this)))`.

--- a/docs/implicit_conversion_dispatch/accessor.md
+++ b/docs/implicit_conversion_dispatch/accessor.md
@@ -2,27 +2,27 @@
 
 ```cpp
 // (1)
-template <class F, class C, class... Os>
+template <class F, bool IsDirect, class D, class... Os>
 struct accessor {
   accessor() = delete;
 };
 
 // (2)
-template <class F, class C, class... Os>
-    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, C, Os>> && ...))
-struct accessor<F, C, Os...> : accessor<F, C, Os>... {
-  using accessor<F, C, Os>::operator return-type-of<Os>...;
+template <class F, bool IsDirect, class D, class... Os>
+    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, IsDirect, D, Os>> && ...))
+struct accessor<F, IsDirect, D, Os...> : accessor<F, IsDirect, D, Os>... {
+  using accessor<F, IsDirect, D, Os>::operator return-type-of<Os>...;
 };
 
 // (3)
-template <class F, class C>
-struct accessor<F, C, T() cv ref noex> {
+template <class F, bool IsDirect, class D>
+struct accessor<F, IsDirect, D, T() cv ref noex> {
   operator T() cv ref noex;
 };
 ```
 
 `(1)` The default implementation of `accessor` is not constructible.
 
-`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, C, Os>...` are default-constructible, inherits all `accessor<F, C, Os>...` types and `using` their `operator return-type-of<Os>`. `return-type-of<O>` denotes the *return type* of the overload type `O`.
+`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, IsDirect, D, Os>...` are default-constructible, inherits all `accessor<F, IsDirect, D, Os>...` types and `using` their `operator return-type-of<Os>`. `return-type-of<O>` denotes the *return type* of the overload type `O`.
 
-`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an implicit  `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<C, T() cv ref noex>(access_proxy<F>(std::forward<accessor cv ref>(*this)))`.
+`(3)` When `sizeof...(Os)` is `1` and the only type `O` in `Os` is `T() cv ref noex`, provides an implicit  `operator T()` with the same *cv ref noex* specifiers. `accessor::operator T()` is equivalent to `return proxy_invoke<IsDirect, D, T() cv ref noex>(access_proxy<F>(std::forward<accessor cv ref>(*this)))`.

--- a/docs/operator_dispatch/accessor.md
+++ b/docs/operator_dispatch/accessor.md
@@ -2,7 +2,7 @@
 
 ```cpp
 // (1)
-template <class F, class C, class... Os>
+template <class F, bool IsDirect, class D, class... Os>
 struct accessor {
   accessor() = delete;
 };
@@ -16,14 +16,14 @@ For different `Sign` and `Rhs`, `operator_dispatch<Sign, Rhs>::accessor` has dif
 
 ```cpp
 // (2)
-template <class F, class C, class... Os>
-    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, C, Os>> && ...))
-struct accessor<F, C, Os...> : accessor<F, C, Os>... {
-  using accessor<F, C, Os>::operator sop...;
+template <class F, bool IsDirect, class D, class... Os>
+    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, IsDirect, D, Os>> && ...))
+struct accessor<F, IsDirect, D, Os...> : accessor<F, IsDirect, D, Os>... {
+  using accessor<F, IsDirect, D, Os>::operator sop...;
 };
 ```
 
-`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, C, Os>...` are default-constructible types, inherits all `accessor<F, C, Os>...` types and `using` their `operator sop`.
+`(2)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, IsDirect, D, Os>...` are default-constructible types, inherits all `accessor<F, IsDirect, D, Os>...` types and `using` their `operator sop`.
 
 When `Rhs` is `false`, the other specializations are defined as follows, where `sizeof...(Os)` is `1` and the only type `O` qualified with `cv ref noex` (let `ACCESS_PROXY_EXPR` be `access_proxy<F>(std::forward<accessor cv ref>(*this))`):
 
@@ -33,13 +33,13 @@ When `Sign` is one of `"+"`, `"-"`, `"*"`, `"/"`, `"%"`, `"++"`, `"--"`, `"=="`,
 
 ```cpp
 // (3)
-template <class F, class C, class R, class... Args>
-struct accessor<F, C, R(Args...) cv ref noex> {
+template <class F, bool IsDirect, class D, class R, class... Args>
+struct accessor<F, IsDirect, D, R(Args...) cv ref noex> {
   R operator sop (Args... args) cv ref noex;
 }
 ```
 
-`(3)` Provides an `operator sop(Args...)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Args...)` is equivalent to `return proxy_invoke<C, R(Args...) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Args>(args)...)`.
+`(3)` Provides an `operator sop(Args...)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Args...)` is equivalent to `return proxy_invoke<IsDirect, D, R(Args...) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Args>(args)...)`.
 
 ### `!` and `~`
 
@@ -47,13 +47,13 @@ When `Sign` is either `!` and `~`,
 
 ```cpp
 // (4)
-template <class F, class C, class R>
-struct accessor<F, C, R() cv ref noex> {
+template <class F, bool IsDirect, class D, class R>
+struct accessor<F, IsDirect, D, R() cv ref noex> {
   R operator sop () cv ref noex;
 }
 ```
 
-`(4)` Provides an `operator sop()` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop()` is equivalent to `return proxy_invoke<C, R() cv ref noex>(ACCESS_PROXY_EXPR)`.
+`(4)` Provides an `operator sop()` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop()` is equivalent to `return proxy_invoke<IsDirect, D, R() cv ref noex>(ACCESS_PROXY_EXPR)`.
 
 ### Assignment SOPs
 
@@ -61,26 +61,26 @@ When `Sign` is one of `"+="`, `"-="`, `"*="`, `"/="`, `"&="`, `"|="`, `"^="`, `"
 
 ```cpp
 // (5)
-template <class F, class C, class R, class Arg>
-struct accessor<F, C, R(Arg) cv ref noex> {
+template <class F, bool IsDirect, class D, class R, class Arg>
+struct accessor<F, IsDirect, D, R(Arg) cv ref noex> {
   /* see below */ operator sop (Arg arg) cv ref noex;
 }
 ```
 
-`(4)` Provides an `operator sop(Arg)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Arg)` calls `proxy_invoke<C, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))` and returns `ACCESS_PROXY_EXPR` when `C::is_direct` is `true`, or otherwise, returns `*ACCESS_PROXY_EXPR` when `C::is_direct` is `false`.
+`(4)` Provides an `operator sop(Arg)` with the same *cv ref noex* specifiers as of the overload type. `accessor::operator sop(Arg)` calls `proxy_invoke<IsDirect, D, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))` and returns `ACCESS_PROXY_EXPR` when `IsDirect` is `true`, or otherwise, returns `*ACCESS_PROXY_EXPR` when `IsDirect` is `false`.
 
 ## Right-Hand-Side Operand Specializations
 
 ```cpp
 // (6)
-template <class F, class C, class... Os>
-    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, C, Os>> && ...))
-struct accessor<F, C, Os...> : accessor<F, C, Os>... {};
+template <class F, bool IsDirect, class D, class... Os>
+    requires(sizeof...(Os) > 1u && (std::is_constructible_v<accessor<F, IsDirect, D, Os>> && ...))
+struct accessor<F, IsDirect, D, Os...> : accessor<F, IsDirect, D, Os>... {};
 ```
 
-`(6)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, C, Os>...` are default-constructible types, inherits all `accessor<F, C, Os>...` types.
+`(6)` When `sizeof...(Os)` is greater than `1`, and `accessor<F, IsDirect, D, Os>...` are default-constructible types, inherits all `accessor<F, IsDirect, D, Os>...` types.
 
-When `Rhs` is `true`, the other specializations are defined as follows, where `sizeof...(Os)` is `1` and the only type `O` qualified with `cv ref noex` (let `accessor_arg` be `std::conditional_t<C::is_direct, proxy<F>, proxy_indirect_accessor<F>>`, `ACCESS_PROXY_EXPR` be `access_proxy<F>(std::forward<accessor_arg cv ref>(self))`):
+When `Rhs` is `true`, the other specializations are defined as follows, where `sizeof...(Os)` is `1` and the only type `O` qualified with `cv ref noex` (let `accessor_arg` be `std::conditional_t<IsDirect, proxy<F>, proxy_indirect_accessor<F>>`, `ACCESS_PROXY_EXPR` be `access_proxy<F>(std::forward<accessor_arg cv ref>(self))`):
 
 ### Regular SOPs
 
@@ -88,13 +88,13 @@ When `Sign` is one of `"+"`, `"-"`, `"*"`, `"/"`, `"%"`, `"=="`, `"!="`, `">"`, 
 
 ```cpp
 // (7)
-template <class F, class C, class R, class Arg>
-struct accessor<F, C, R(Arg) cv ref noex> {
+template <class F, bool IsDirect, class D, class R, class Arg>
+struct accessor<F, IsDirect, D, R(Arg) cv ref noex> {
   friend R operator sop (Arg arg, accessor_arg cv ref self) noex;
 }
 ```
 
-`(7)` Provides a `friend operator sop(Arg arg, accessor_arg cv ref self)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor_arg cv ref self)` is equivalent to `return proxy_invoke<C, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))`.
+`(7)` Provides a `friend operator sop(Arg arg, accessor_arg cv ref self)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor_arg cv ref self)` is equivalent to `return proxy_invoke<IsDirect, D, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))`.
 
 ### Assignment SOPs
 
@@ -102,10 +102,10 @@ When `Sign` is one of `"+="`, `"-="`, `"*="`, `"/="`, `"&="`, `"|="`, `"^="`, `"
 
 ```cpp
 // (8)
-template <class F, class C, class R, class Arg>
-struct accessor<F, C, R(Arg) cv ref noex> {
+template <class F, bool IsDirect, class D, class R, class Arg>
+struct accessor<F, IsDirect, D, R(Arg) cv ref noex> {
   friend /* see below */ operator sop (Arg arg, accessor_arg cv ref self) noex;
 }
 ```
 
-`(8)` Provides a `friend operator sop(Arg arg, accessor_arg cv ref self)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor_arg cv ref self)` calls `proxy_invoke<C, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))` and returns `ACCESS_PROXY_EXPR` when `C::is_direct` is `true`, or otherwise, returns `*ACCESS_PROXY_EXPR` when `C::is_direct` is `false`.
+`(8)` Provides a `friend operator sop(Arg arg, accessor_arg cv ref self)` with the same *noex* specifiers as of the overload type. `accessor::operator sop(Arg arg, accessor_arg cv ref self)` calls `proxy_invoke<IsDirect, D, R(Arg) cv ref noex>(ACCESS_PROXY_EXPR, std::forward<Arg>(arg))` and returns `ACCESS_PROXY_EXPR` when `IsDirect` is `true`, or otherwise, returns `*ACCESS_PROXY_EXPR` when `IsDirect` is `false`.

--- a/docs/proxy_invoke.md
+++ b/docs/proxy_invoke.md
@@ -1,30 +1,30 @@
 # Function template `proxy_invoke`
 
 ```cpp
-template <class C, class O, class F, class... Args>
+template <bool IsDirect, class D, class O, class F, class... Args>
 /* see below */ proxy_invoke(proxy<F>& p, Args&&... args);
 
-template <class C, class O, class F, class... Args>
+template <bool IsDirect, class D, class O, class F, class... Args>
 /* see below */ proxy_invoke(const proxy<F>& p, Args&&... args);
 
-template <class C, class O, class F, class... Args>
+template <bool IsDirect, class D, class O, class F, class... Args>
 /* see below */ proxy_invoke(proxy<F>&& p, Args&&... args);
 
-template <class C, class O, class F, class... Args>
+template <bool IsDirect, class D, class O, class F, class... Args>
 /* see below */ proxy_invoke(const proxy<F>&& p, Args&&... args);
 ```
 
-Invokes a `proxy` with a specified convention type, an overload type, and arguments. `C` is required to be defined in `typename F::convention_types`. `O` is required to be defined in `typename C::overload_types`.
+Invokes a `proxy` with a specified dispatch type, an overload type, and arguments. There shall be a convention type `Conv` defined in `typename F::convention_types` where `Conv::is_direct == IsDirect && std::is_same_v<typename Conv::dispatch_type, D>` is `true`. `O` is required to be defined in `typename Conv::overload_types`.
 
 Let `ptr` be the contained value of `p` with the same cv ref-qualifiers, `Args2...` be the argument types of `O`, `R` be the return type of `O`,
 
-- if `C::is_direct` is `true`, let `v` be `std::forward<decltype(ptr)>(ptr)`, or otherwise,
-- if `C::is_direct` is `false`, let `v` be `*std::forward<decltype(ptr)>(ptr)`,
+- if `IsDirect` is `true`, let `v` be `std::forward<decltype(ptr)>(ptr)`, or otherwise,
+- if `IsDirect` is `false`, let `v` be `*std::forward<decltype(ptr)>(ptr)`,
 
 equivalent to:
 
-- [`INVOKE<R>`](https://en.cppreference.com/w/cpp/utility/functional)`(typename C::dispatch_type{}, std::forward<decltype(v)>(v), static_cast<Args2>(args)...)` if the expression is well-formed, or otherwise,
-- [`INVOKE<R>`](https://en.cppreference.com/w/cpp/utility/functional)`(typename C::dispatch_type{}, nullptr, static_cast<Args2>(args)...)`.
+- [`INVOKE<R>`](https://en.cppreference.com/w/cpp/utility/functional)`(D{}, std::forward<decltype(v)>(v), static_cast<Args2>(args)...)` if the expression is well-formed, or otherwise,
+- [`INVOKE<R>`](https://en.cppreference.com/w/cpp/utility/functional)`(D{}, nullptr, static_cast<Args2>(args)...)`.
 
 The behavior is undefined if `p` does not contain a value.
 
@@ -32,8 +32,8 @@ The behavior is undefined if `p` does not contain a value.
 
 It is generally not recommended to call `proxy_invoke` directly. Using an [`accessor`](ProAccessible.md) is usually a better option with easier and more descriptive syntax. If the facade type `F` is defined with the recommended facilities, it has full accessibility support. Specifically, when
 
-- the underlying dispatch type `typename C::dispatch_type` is defined via [macro `PRO_DEF_MEM_DISPATCH`](PRO_DEF_MEM_DISPATCH.md), [macro `PRO_DEF_FREE_DISPATCH`](PRO_DEF_FREE_DISPATCH.md), or is a specialization of either [`operator_dispatch`](operator_dispatch.md) or [`conversion_dispatch`](conversion_dispatch.md), and
-- the convention is defined via [`facade_builder`](basic_facade_builder.md).
+- `D` is defined via [macro `PRO_DEF_MEM_DISPATCH`](PRO_DEF_MEM_DISPATCH.md), [macro `PRO_DEF_FREE_DISPATCH`](PRO_DEF_FREE_DISPATCH.md), or is a specialization of either [`operator_dispatch`](operator_dispatch.md) or [`conversion_dispatch`](conversion_dispatch.md), and
+- the convention type `Conv` is defined via [`facade_builder`](basic_facade_builder.md).
 
 ## Example
 
@@ -53,9 +53,7 @@ int main() {
   int a = 123;
   pro::proxy<Stringable> p = &a;
   std::cout << ToString(*p) << "\n";  // Invokes with accessor, prints: "123"
-
-  using C = std::tuple_element_t<0u, Stringable::convention_types>;
-  std::cout << pro::proxy_invoke<C, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
+  std::cout << pro::proxy_invoke<false, FreeToString, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
 }
 ```
 

--- a/docs/proxy_reflect.md
+++ b/docs/proxy_reflect.md
@@ -1,11 +1,11 @@
 # Function template `proxy_reflect`
 
 ```cpp
-template <class R, class F>
-/* see below */ proxy_reflect(const proxy<F>& p) noexcept;
+template <bool IsDirect, class R, class F>
+const R& proxy_reflect(const proxy<F>& p) noexcept;
 ```
 
-Let `P` be the type of the contained value of `p`. Retrieves a value of type `const typename R::reflector_type&` constructed from [`std::in_place_type<T>`](https://en.cppreference.com/w/cpp/utility/in_place), where `T` is `P` when `R::is_direct` is `true`, or otherwise `T` is `typename std::pointer_traits<P>::element_type` when `R::is_direct` is `false`. `R` is required to be defined in `typename F::reflection_types`. The behavior is undefined if `p` does not contain a value.
+Let `P` be the type of the contained value of `p`. Retrieves a value of type `const R&` constructed from [`std::in_place_type<T>`](https://en.cppreference.com/w/cpp/utility/in_place), where `T` is `P` when `IsDirect` is `true`, or otherwise `T` is `typename std::pointer_traits<P>::element_type` when `IsDirect` is `false`. There shall be a reflection type `Refl` defined in `typename F::reflection_types` where `Refl::is_direct == IsDirect && std::is_same_v<typename Refl::reflection_type, R>` is `true`. The behavior is undefined if `p` does not contain a value.
 
 The reference obtained from `proxy_reflect()` may be invalidated if `p` is subsequently modified.
 
@@ -28,10 +28,10 @@ class CopyabilityReflector {
   constexpr explicit CopyabilityReflector(std::in_place_type_t<T>)
       : copyable_(std::is_copy_constructible_v<T>) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     bool IsCopyable() const noexcept {
-      const CopyabilityReflector& self = pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      const CopyabilityReflector& self = pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
       return self.copyable_;
     }
   };

--- a/samples/access_proxy.cpp
+++ b/samples/access_proxy.cpp
@@ -20,13 +20,12 @@ int main() {
   std::cout << ToString(*p) << "\n";  // Prints: "123"
 
   // How it works behind the scenes
-  using Convention = std::tuple_element_t<0u, Stringable::convention_types>;
-  using Accessor = Convention::accessor<Stringable>;
+  using Accessor = FreeToString::accessor<Stringable, false, FreeToString, std::string()>;
   static_assert(std::is_base_of_v<Accessor, std::remove_reference_t<decltype(*p)>>);
   Accessor& a = static_cast<Accessor&>(*p);
   pro::proxy<Stringable>& p2 = pro::access_proxy<Stringable>(a);
   std::cout << std::boolalpha << (&p == &p2) << "\n";  // Prints: "true" because access_proxy converts
                                                        // an accessor back to the original proxy
-  auto result = pro::proxy_invoke<Convention, std::string()>(p2);
+  auto result = pro::proxy_invoke<false, FreeToString, std::string()>(p2);
   std::cout << result << "\n";  // Prints: "123"
 }

--- a/samples/basic_facade_builder/add_reflection.cpp
+++ b/samples/basic_facade_builder/add_reflection.cpp
@@ -12,10 +12,10 @@ class RttiReflector {
   template <class T>
   constexpr explicit RttiReflector(std::in_place_type_t<T>) : type_(typeid(T)) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     const char* GetTypeName() const noexcept {
-      const RttiReflector& self = pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      const RttiReflector& self = pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
       return self.type_.name();
     }
   };

--- a/samples/proxy_invoke.cpp
+++ b/samples/proxy_invoke.cpp
@@ -17,7 +17,5 @@ int main() {
   int a = 123;
   pro::proxy<Stringable> p = &a;
   std::cout << ToString(*p) << "\n";  // Invokes with accessor, prints: "123"
-
-  using C = std::tuple_element_t<0u, Stringable::convention_types>;
-  std::cout << pro::proxy_invoke<C, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
+  std::cout << pro::proxy_invoke<false, FreeToString, std::string() const>(p) << "\n";  // Invokes with proxy_invoke, also prints: "123"
 }

--- a/samples/proxy_reflect.cpp
+++ b/samples/proxy_reflect.cpp
@@ -14,10 +14,10 @@ class CopyabilityReflector {
   constexpr explicit CopyabilityReflector(std::in_place_type_t<T>)
       : copyable_(std::is_copy_constructible_v<T>) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     bool IsCopyable() const noexcept {
-      const CopyabilityReflector& self = pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      const CopyabilityReflector& self = pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
       return self.copyable_;
     }
   };

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -20,10 +20,10 @@ struct SboReflector {
   constexpr explicit SboReflector(std::in_place_type_t<pro::details::compact_ptr<T, Alloc>>)
       : SboEnabled(false), AllocatorAllocatesForItself(true) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     const SboReflector& ReflectSbo() const noexcept {
-      return pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      return pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
     }
   };
 

--- a/tests/proxy_reflection_tests.cpp
+++ b/tests/proxy_reflection_tests.cpp
@@ -19,10 +19,10 @@ struct TraitsReflector {
         is_nothrow_destructible_(std::is_nothrow_destructible_v<T>),
         is_trivial_(std::is_trivial_v<T>) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     const TraitsReflector& ReflectTraits() const noexcept {
-      return pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      return pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
     }
   };
 

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -298,7 +298,7 @@ struct BadFacade_BadReflectionType {
       .destructibility = pro::constraint_level::nothrow,
   };
 };
-static_assert(pro::facade<BadFacade_BadReflectionType>);
+static_assert(!pro::facade<BadFacade_BadReflectionType>);
 
 PRO_DEF_MEM_DISPATCH(MemFoo, Foo);
 PRO_DEF_MEM_DISPATCH(MemBar, Bar);

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -97,10 +97,10 @@ class RttiReflector {
   template <class T>
   constexpr explicit RttiReflector(std::in_place_type_t<T>) : type_(typeid(T)) {}
 
-  template <class F, class R>
+  template <class F, bool IsDirect, class R>
   struct accessor {
     const char* GetTypeName() const noexcept {
-      const RttiReflector& self = pro::proxy_reflect<R>(pro::access_proxy<F>(*this));
+      const RttiReflector& self = pro::proxy_reflect<IsDirect, R>(pro::access_proxy<F>(*this));
       return self.type_.name();
     }
   };


### PR DESCRIPTION
**Motivation**

In the current design, `proxy_invoke()` and the accessor of a convention type (specifically `details::conv_impl`) take the convention type as their template parameter. Similarly, `proxy_reflect()` and the accessor of a reflection type (specifically details::refl_impl`) also take the reflection type as their template parameter. The abuse of convention types and reflection types on these definitions makes their semantics more complex than necessary. Simplifying their definitions makes it easier to reason the code.

For example, for the following facade definition:

```cpp
PRO_DEF_MEM_DISPATCH(MemFoo, Foo);

struct MyFacade : pro::facade_builder
    ::add_convention<MemFoo, void(), void(int)>
    ::build {};
```

Before this change, `proxy_indirect_accessor<MyFacade>` inherits the following two types:

```cpp
MemFoo::accessor<MyFacade, pro::details::conv_impl<false, MemFoo, void(), void(int)>, void()>
MemFoo::accessor<MyFacade, pro::details::conv_impl<false, MemFoo, void(), void(int)>, void(int)>
```

After this change, the two types become:

```cpp
MemFoo::accessor<MyFacade, false, MemFoo, void()>
MemFoo::accessor<MyFacade, false, MemFoo, void(int)>
```

Although this change has no runtime side effects, it can potentially improve compilation speed especially when a convention type has multiple overloads.

**Changes**

- Updated the definition of `proxy_invoke`. The first template parameter (convention type `C`) was replaced by a boolean flag (equivalent to prior `C::is_direct`) and a dispatch type (equivalent to prior `typename C::dispatch_type`).
- Updated the definition of `proxy_reflect`. The first template parameter (reflection type `R`) was replaced by a boolean flag (equivalent to prior `R::is_direct`) and a reflector type (equivalent to prior `typename R::reflector_type`).
- Updated the definition of the accessors in the library.
- Revised the implementation of `concept facade<F>` to detect correctness of each reflection type defined in `typename F::reflection_types`. Also fixed the corresponding test case in `proxy_traits_tests.cpp`.
- Revised the semantics of the `ProAccessible` requirements.
- Updated unit tests accordingly.
- Updated spec accordingly.