### PR TITLE
Feature: Support for `std::format`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ FetchContent_MakeAvailable(googletest)
 add_executable(msft_proxy_tests
   proxy_creation_tests.cpp
   proxy_dispatch_tests.cpp
+  proxy_format_tests.cpp
   proxy_integration_tests.cpp
   proxy_invocation_tests.cpp
   proxy_lifetime_tests.cpp

--- a/tests/proxy_format_tests.cpp
+++ b/tests/proxy_format_tests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+#include "proxy.h"
+
+namespace proxy_format_tests_details {
+
+struct TestFacade : pro::facade_builder
+    ::support_format
+    ::support_wformat
+    ::build {};
+
+}  // namespace proxy_format_tests_details
+
+namespace details = proxy_format_tests_details;
+
+TEST(ProxyFormatTests, TestFormat_Null) {
+  pro::proxy<details::TestFacade> p;
+  bool exception_thrown = false;
+  try {
+    std::ignore = std::format("{}", *p);
+  } catch (const std::format_error&) {
+    exception_thrown = true;
+  }
+  ASSERT_TRUE(exception_thrown);
+}
+
+TEST(ProxyFormatTests, TestFormat_Value) {
+  int v = 123;
+  pro::proxy<details::TestFacade> p = &v;
+  ASSERT_EQ(std::format("{}", *p), "123");
+  ASSERT_EQ(std::format("{:*<6}", *p), "123***");
+}
+
+TEST(ProxyFormatTests, TestWformat_Null) {
+  pro::proxy<details::TestFacade> p;
+  bool exception_thrown = false;
+  try {
+    std::ignore = std::format(L"{}", *p);
+  } catch (const std::format_error&) {
+    exception_thrown = true;
+  }
+  ASSERT_TRUE(exception_thrown);
+}
+
+TEST(ProxyFormatTests, TestWformat_Value) {
+  int v = 123;
+  pro::proxy<details::TestFacade> p = &v;
+  ASSERT_EQ(std::format(L"{}", *p), L"123");
+  ASSERT_EQ(std::format(L"{:*<6}", *p), L"123***");
+}


### PR DESCRIPTION
**Changes**

- Added options `support_format` and `support_wformat` to `basic_facade_builder` to enable support for `std::format()`.
- Added unit tests accordingly.

Documentation and sample code will be updated later.