### PR TITLE
Fix `swap` for trivial proxy

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -903,7 +903,7 @@ class proxy : public details::facade_traits<F>::direct_accessor {
     if constexpr (F::constraints.relocatability == constraint_level::trivial ||
         F::constraints.copyability == constraint_level::trivial) {
       std::swap(meta_, rhs.meta_);
-      std::swap(ptr_, rhs.ptr);
+      std::swap(ptr_, rhs.ptr_);
     } else {
       if (meta_.has_value()) {
         if (rhs.meta_.has_value()) {

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -974,6 +974,16 @@ TEST(ProxyLifetimeTests, TestSwap_Null_Null) {
   ASSERT_FALSE(p2.has_value());
 }
 
+TEST(ProxyLifetimeTests, TestSwap_Trivial) {
+  pro::proxy<details::TestTrivialFacade> p1 = pro::make_proxy<details::TestTrivialFacade>(123);
+  pro::proxy<details::TestTrivialFacade> p2 = pro::make_proxy<details::TestTrivialFacade>(456);
+  swap(p1, p2);
+  ASSERT_TRUE(p1.has_value());
+  ASSERT_EQ(ToString(*p1), "456");
+  ASSERT_TRUE(p2.has_value());
+  ASSERT_EQ(ToString(*p2), "123");
+}
+
 TEST(ProxyLifetimeTests, Test_DirectConvension_Lvalue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;


### PR DESCRIPTION
This branch has a typo and was never covered, thanks to `if constexpr`... Resolves #245