### PR TITLE
Improve constraints on `make_proxy` and `allocate_proxy`

### DIFF
--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -80,6 +80,9 @@ static_assert(!pro::inplace_proxiable_target<utils::LifetimeTracker::Session, Te
 static_assert(!noexcept(pro::make_proxy_inplace<TestLargeStringable, utils::LifetimeTracker::Session>(std::declval<utils::LifetimeTracker*>())));
 static_assert(noexcept(pro::make_proxy_inplace<TestLargeStringable, int>(123)));
 
+static_assert(pro::proxiable_target<utils::LifetimeTracker::Session, TestLargeStringable>);
+static_assert(pro::proxiable_target<utils::LifetimeTracker::Session, TestSmallStringable>);
+
 template <class T>
 void SfinaeUnsafeIncrementImpl(T&& value) { ++value; }
 


### PR DESCRIPTION
Added a bunch of `noexcept` and `requires` constraints to `make_proxy` and `allocate_proxy` to ensure accurate diagnostics. Added static assertions in unit tests. Resolves #247.