### PR TITLE
Allow creating `proxy` from a null pointer

### DIFF
--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -39,9 +39,15 @@ TEST(ProxyLifetimeTests, TestDefaultConstrction) {
   ASSERT_FALSE(p.has_value());
 }
 
-TEST(ProxyLifetimeTests, TestNullConstrction) {
+TEST(ProxyLifetimeTests, TestNullConstrction_Nullptr) {
   pro::proxy<details::TestFacade> p = nullptr;
   ASSERT_FALSE(p.has_value());
+}
+
+TEST(ProxyLifetimeTests, TestNullConstrction_TypedNullPointer) {
+  int* v = nullptr;
+  pro::proxy<utils::spec::Stringable> p = v;
+  ASSERT_TRUE(p.has_value());
 }
 
 TEST(ProxyLifetimeTests, TestPolyConstrction_FromValue) {
@@ -237,7 +243,7 @@ TEST(ProxyLifetimeTests, TestMoveConstrction_FromNull) {
   ASSERT_FALSE(p2.has_value());
 }
 
-TEST(ProxyLifetimeTests, TestNullAssignment_ToValue) {
+TEST(ProxyLifetimeTests, TestNullAssignment_FromNullptr_ToValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;
   {
@@ -249,6 +255,12 @@ TEST(ProxyLifetimeTests, TestNullAssignment_ToValue) {
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   ASSERT_TRUE(tracker.GetOperations() == expected_ops);
+}
+
+TEST(ProxyLifetimeTests, TestNullAssignment_FromTypedNullPointer_ToValue) {
+  pro::proxy<utils::spec::Stringable> p = pro::make_proxy<utils::spec::Stringable>(123);
+  p = std::shared_ptr<int>{};
+  ASSERT_TRUE(p.has_value());
 }
 
 TEST(ProxyLifetimeTests, TestNullAssignment_ToNull) {


### PR DESCRIPTION
Resolves #259. Added unit tests accordingly.