### PR TITLE
Relax the constraints on `basic_facade_builder::support_weak`

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -1324,6 +1324,8 @@ class strong_compact_ptr
   using Storage = strong_weak_compact_ptr_storage<T, Alloc>;
 
  public:
+  using weak_type = weak_compact_ptr<T, Alloc>;
+
   template <class... Args>
   strong_compact_ptr(const Alloc& alloc, Args&&... args)
       : indirect_ptr<Storage>(allocate<Storage>(
@@ -2016,12 +2018,11 @@ sign(const char (&str)[N]) -> sign<N>;
 
 #if __STDC_HOSTED__
 struct weak_conversion_dispatch : cast_dispatch_base<false, true> {
-  template <class T>
-  auto operator()(const std::shared_ptr<T>& self) const noexcept
-      { return std::weak_ptr<T>{self}; }
-  template <class T, class Alloc>
-  auto operator()(const strong_compact_ptr<T, Alloc>& self) const noexcept
-      { return weak_compact_ptr<T, Alloc>{self}; }
+  template <class P>
+  auto operator()(const P& self) const noexcept
+      requires(requires { typename P::weak_type; } &&
+          std::is_convertible_v<const P&, typename P::weak_type>)
+      { return typename P::weak_type{self}; }
 };
 template <class F>
 using weak_conversion_overload = weak_proxy<F>() const noexcept;
@@ -2043,11 +2044,9 @@ class nullable_ptr_adapter {
  private:
   P ptr_;
 };
-template <class T>
-auto weak_lock_impl(const std::weak_ptr<T>& self) noexcept
-    { return nullable_ptr_adapter{self.lock()}; }
-template <class T, class Alloc>
-auto weak_lock_impl(const weak_compact_ptr<T, Alloc>& self) noexcept
+template <class P>
+auto weak_lock_impl(const P& self) noexcept
+    requires(requires { static_cast<bool>(self.lock()); })
     { return nullable_ptr_adapter{self.lock()}; }
 PRO_DEF_FREE_AS_MEM_DISPATCH(weak_mem_lock, weak_lock_impl, lock);
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -118,6 +118,9 @@ struct TestWeakSharedStringable: pro::facade_builder
     ::support_weak
     ::build {};
 
+static_assert(pro::proxiable<int*, TestSharedStringable>);
+static_assert(!pro::proxiable<int*, TestWeakSharedStringable>);
+
 }  // namespace proxy_creation_tests_details
 
 namespace details = proxy_creation_tests_details;


### PR DESCRIPTION
Before this change, only `std::shared_ptr` and the return type of `(allocate|make)_proxy()` can instantiate a `proxy<F>` if `F` was built with `support_weak`. The constraints can be relaxed since `std::shared_ptr` has a member type `weak_type`. After this change, any pointer type that has implemented a `weak_type` can work with `support_weak`.