### PR TITLE
Attach environment information to benchmarking report

### DIFF
--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -23,14 +23,16 @@ jobs:
         cmake -B build -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release
         cmake --build build -j
         ctest --test-dir build -j
+        mkdir build/drop
+        chmod +x tools/dump_build_env.sh
+        ./tools/dump_build_env.sh clang++ build/drop/env-info.json
 
     - name: run benchmarks
       run: |
-        cd build/benchmarks
-        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+        build/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/drop/benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarking-results-appleclang
-        path: build/benchmarks/benchmarking-results.json
+        name: drop-appleclang
+        path: build/drop/

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -26,14 +26,16 @@ jobs:
         cmake -B build -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release
         cmake --build build -j
         ctest --test-dir build -j
+        mkdir build/drop
+        chmod +x tools/dump_build_env.sh
+        ./tools/dump_build_env.sh clang++-19 build/drop/env-info.json
 
     - name: run benchmarks
       run: |
-        cd build/benchmarks
-        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+        build/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/drop/benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarking-results-clang
-        path: build/benchmarks/benchmarking-results.json
+        name: drop-clang
+        path: build/drop/

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -26,14 +26,16 @@ jobs:
         cmake -B build -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release
         cmake --build build -j
         ctest --test-dir build -j
+        mkdir build/drop
+        chmod +x tools/dump_build_env.sh
+        ./tools/dump_build_env.sh g++-14 build/drop/env-info.json
 
     - name: run benchmarks
       run: |
-        cd build/benchmarks
-        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+        build/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/drop/benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarking-results-gcc
-        path: build/benchmarks/benchmarking-results.json
+        name: drop-gcc
+        path: build/drop/

--- a/.github/workflows/bvt-msvc.yml
+++ b/.github/workflows/bvt-msvc.yml
@@ -13,19 +13,23 @@ jobs:
       with:
         ref: ${{ inputs.branch }}
 
+    - name: add cl.exe to PATH
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: build and run test with MSVC
       run: |
         cmake -B build -DCMAKE_CXX_STANDARD=23
         cmake --build build --config Release -j
         ctest --test-dir build -j
+        mkdir build\drop > $null
+        .\tools\dump_build_env_msvc.ps1 -OutputPath build\drop\env-info.json
 
     - name: run benchmarks
       run: |
-        cd build\benchmarks
-        .\Release\msft_proxy_benchmarks.exe --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+        build\benchmarks\Release\msft_proxy_benchmarks.exe --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build\drop\benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarking-results-msvc
-        path: build/benchmarks/benchmarking-results.json
+        name: drop-msvc
+        path: build/drop/

--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -26,14 +26,16 @@ jobs:
         cmake -B build -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++ -DCMAKE_BUILD_TYPE=Release
         cmake --build build -j
         ctest --test-dir build -j
+        mkdir build/drop
+        chmod +x tools/dump_build_env.sh
+        ./tools/dump_build_env.sh nvc++ build/drop/env-info.json
 
     - name: run benchmarks
       run: |
-        cd build/benchmarks
-        ./msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > benchmarking-results.json
+        build/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/drop/benchmarking-results.json
 
     - name: archive benchmarking results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarking-results-nvhpc
-        path: build/benchmarks/benchmarking-results.json
+        name: drop-nvhpc
+        path: build/drop/

--- a/.github/workflows/bvt-report.yml
+++ b/.github/workflows/bvt-report.yml
@@ -27,7 +27,7 @@ jobs:
     - name: generate report
       run: |
         cat <<EOF > benchmarking-report.md
-        ## Benchmarking Report
+        # Benchmarking Report
 
         - Generated for: [Microsoft "Proxy" library](https://github.com/microsoft/proxy)
         - Commit ID: [${{ github.sha }}](https://github.com/microsoft/proxy/commit/${{ github.sha }})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(msft_proxy VERSION 3.2.1 LANGUAGES CXX)
 add_library(msft_proxy INTERFACE)

--- a/tools/dump_build_env.sh
+++ b/tools/dump_build_env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <compiler> <output path>"
+  exit 1
+fi
+
+COMPILER_INFO="$("$1" --version 2>/dev/null | awk 'NF {print; exit}')"
+if [ -z "$COMPILER_INFO" ]; then
+  echo "Unable to retrieve compiler info for '$1'."
+  exit 1
+fi
+
+OS_NAME="$(uname -s)"
+if [ "$OS_NAME" = "Linux" ]; then
+  if [ -f /etc/os-release ]; then
+    OS_NAME="$(grep ^PRETTY_NAME= /etc/os-release | cut -d= -f2 | tr -d '"')"
+  fi
+elif [ "$OS_NAME" = "Darwin" ]; then
+  OS_NAME="$(sw_vers -productName) $(sw_vers -productVersion)"
+fi
+
+cat <<EOF > $2
+{
+  "OS": "$OS_NAME",
+  "KernelVersion": "$(uname -r)",
+  "Architecture": "$(uname -m)",
+  "Compiler": "$COMPILER_INFO"
+}
+EOF

--- a/tools/dump_build_env_msvc.ps1
+++ b/tools/dump_build_env_msvc.ps1
@@ -5,7 +5,6 @@ param(
 )
 
 $osInfo = Get-CimInstance Win32_OperatingSystem
-cl /? | Out-String
 $compiler = ((cl /? 2>&1 | Out-String) -split '\r')[0] -replace '^cl\s:\s',''
 $jsonObject = [ordered]@{
     OS = $osInfo.Caption

--- a/tools/dump_build_env_msvc.ps1
+++ b/tools/dump_build_env_msvc.ps1
@@ -1,0 +1,16 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$OutputPath
+)
+
+$osInfo = Get-CimInstance Win32_OperatingSystem
+cl /? | Out-String
+$compiler = ((cl /? 2>&1 | Out-String) -split '\r')[0] -replace '^cl\s:\s',''
+$jsonObject = [ordered]@{
+    OS = $osInfo.Caption
+    KernelVersion = $osInfo.Version
+    Architecture = $env:PROCESSOR_ARCHITECTURE
+    Compiler = $compiler
+} | ConvertTo-Json
+Set-Content -Path $OutputPath -Value $jsonObject

--- a/tools/report_generator/report-config.json
+++ b/tools/report_generator/report-config.json
@@ -4,24 +4,29 @@
   "OutputPath": "benchmarking-report.md",
   "Environments": [
     {
-      "Description": "MSVC on Windows Server 2022 (x64)",
-      "Path": "artifacts/benchmarking-results-msvc/benchmarking-results.json"
+      "Description": "MSVC on Windows",
+      "InfoPath": "artifacts/drop-msvc/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-msvc/benchmarking-results.json"
     },
     {
-      "Description": "GCC on Ubuntu 24.04 (x64)",
-      "Path": "artifacts/benchmarking-results-gcc/benchmarking-results.json"
+      "Description": "GCC on Ubuntu",
+      "InfoPath": "artifacts/drop-gcc/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-gcc/benchmarking-results.json"
     },
     {
-      "Description": "Clang on Ubuntu 24.04 (x64)",
-      "Path": "artifacts/benchmarking-results-clang/benchmarking-results.json"
+      "Description": "Clang on Ubuntu",
+      "InfoPath": "artifacts/drop-clang/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-clang/benchmarking-results.json"
     },
     {
-      "Description": "Apple Clang on macOS 15 (ARM64)",
-      "Path": "artifacts/benchmarking-results-appleclang/benchmarking-results.json"
+      "Description": "Apple Clang on macOS",
+      "InfoPath": "artifacts/drop-appleclang/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-appleclang/benchmarking-results.json"
     },
     {
-      "Description": "NVIDIA HPC on Ubuntu 24.04 (x64)",
-      "Path": "artifacts/benchmarking-results-nvhpc/benchmarking-results.json"
+      "Description": "NVIDIA HPC on Ubuntu",
+      "InfoPath": "artifacts/drop-nvhpc/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-nvhpc/benchmarking-results.json"
     }
   ],
   "Metrics": [


### PR DESCRIPTION
Example:

## Environment

| | Operating System | Kernel Version | Architecture | Compiler |
| - | - | - | - | - |
| **MSVC on Windows Server** | Microsoft Windows Server 2025 Datacenter | 10.0.26100 | AMD64 | Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34808 for x64 |
| **GCC on Ubuntu** | Ubuntu 24.04.2 LTS | 6.8.0-1021-azure | x86_64 | g++-14 (Ubuntu 14.2.0-4ubuntu2~24.04) 14.2.0 |
| **Clang on Ubuntu** | Ubuntu 24.04.2 LTS | 6.8.0-1021-azure | x86_64 | Ubuntu clang version 19.1.1 (1ubuntu1~24.04.2) |
| **Apple Clang on macOS** | macOS 15.3.1 | 24.3.0 | arm64 | Apple clang version 16.0.0 (clang-1600.0.26.3) |
| **NVIDIA HPC on Ubuntu** | Ubuntu 24.04.2 LTS | 6.8.0-1021-azure | x86_64 | nvc++ 24.9-0 64-bit target on x86-64 Linux -tp znver3  |

Tested locally. No functional changes.