### PR TITLE
Align behavior of rvalue reference

### DIFF
--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -994,5 +994,6 @@ TEST(ProxyCreationTests, TestMakeProxyView) {
   ASSERT_EQ((*p)(), 0);
   ASSERT_EQ((*std::as_const(p))(), 1);
   ASSERT_EQ((*std::move(p))(), 2);
+  p = pro::make_proxy_view<TestFacade>(test_callable);
   ASSERT_EQ((*std::move(std::as_const(p)))(), 3);
 }

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -333,6 +333,7 @@ TEST(ProxyInvocationTests, TestQualifiedConvention_Member) {
   ASSERT_EQ((*p)(), 0);
   ASSERT_EQ((*std::as_const(p))(), 1);
   ASSERT_EQ((*std::move(p))(), 2);
+  p = pro::make_proxy<TestFacade, TestCallable>();
   ASSERT_EQ((*std::move(std::as_const(p)))(), 3);
 }
 
@@ -347,5 +348,6 @@ TEST(ProxyInvocationTests, TestQualifiedConvention_Free) {
   ASSERT_EQ(Dump(*p), "is_const=false, is_ref=true, value=123");
   ASSERT_EQ(Dump(*std::as_const(p)), "is_const=true, is_ref=true, value=123");
   ASSERT_EQ(Dump(*std::move(p)), "is_const=false, is_ref=false, value=123");
+  p = pro::make_proxy<TestFacade>(123);
   ASSERT_EQ(Dump(*std::move(std::as_const(p))), "is_const=true, is_ref=false, value=123");
 }

--- a/tests/proxy_rtti_tests.cpp
+++ b/tests/proxy_rtti_tests.cpp
@@ -91,8 +91,7 @@ TEST(ProxyRttiTests, TestIndirectCast_Move_Succeed) {
   auto p = pro::make_proxy<details::TestFacade>(v1);
   auto v2 = proxy_cast<std::vector<int>>(std::move(*p));
   ASSERT_EQ(v2, v1);
-  v2 = proxy_cast<std::vector<int>>(std::move(*p));
-  ASSERT_TRUE(v2.empty());
+  ASSERT_FALSE(p.has_value());
 }
 
 TEST(ProxyRttiTests, TestIndirectCast_Move_Fail) {


### PR DESCRIPTION
Before this change invoking a convention with a rvalue reference will destroy the contained value if the convention is direct, while the contained value won't be destroyed if the convention is indirect. This change makes the behavior consistent by destroying the contained value in both cases. Unit tests are updated accordingly.