### PR TITLE
Remove `offsetof` to eliminate undefined behavior

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -772,8 +772,6 @@ struct meta_ptr_reset_guard {
 
 template <class T>
 class inplace_ptr {
-  template <class> friend struct proxy_helper;
-
  public:
   template <class... Args>
   explicit inplace_ptr(std::in_place_t, Args&&... args)


### PR DESCRIPTION
Since `proxy<F>::value_` is now wrapped by `details::inplace_ptr<proxy_indirect_accessor<F>>`, there is no need to use `offsetof` in a non-standard way. Related warning suppression can also be removed.

No functional changes.