### PR TITLE
Improve semantics of `proxy`

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -11,6 +11,12 @@ As per `facade<F>`, `typename F::convention_types` shall be a [tuple-like](https
 
 Any instance of `proxy<F>` at any given point in time either *contains a value* or *does not contain a value*. If a `proxy<F>` *contains a value*, the type of the value shall be a pointer type `P`  where [`proxiable<P, F>`](proxiable.md) is `true`, and the value is guaranteed to be allocated as part of the `proxy` object footprint, i.e. no dynamic memory allocation occurs. However, `P` may allocate during its construction, depending on its implementation.
 
+## Member Types
+
+| Name                               | Description |
+| ---------------------------------- | ----------- |
+| `facade_type`<br />*(since 3.3.1)* | `F`         |
+
 ## Member Functions
 
 | Name                                                       | Description                                        |

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -30,6 +30,7 @@ using MockTrivialPtr = MockPtr<true, true, true, sizeof(void*), alignof(void*)>;
 using MockFunctionPtr = void(*)();
 
 struct DefaultFacade : pro::facade_builder::build {};
+static_assert(std::is_same_v<pro::proxy<DefaultFacade>::facade_type, DefaultFacade>);
 static_assert(DefaultFacade::constraints.copyability == pro::constraint_level::none);
 static_assert(DefaultFacade::constraints.relocatability == pro::constraint_level::nothrow);
 static_assert(DefaultFacade::constraints.destructibility == pro::constraint_level::nothrow);

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -11,6 +11,8 @@ namespace proxy_traits_tests_details {
 
 template <bool kNothrowRelocatable, bool kCopyable, bool kTrivial, std::size_t kSize, std::size_t kAlignment>
 struct MockPtr {
+  using element_type = MockPtr;
+
   MockPtr() = default;
   MockPtr(int) noexcept {}
   MockPtr(const MockPtr&) requires(kCopyable && !kTrivial) {}

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -41,6 +41,8 @@ class LifetimeTracker {
 
   class Session {
    public:
+    using element_type = Session;
+
     Session(LifetimeTracker* host)
         : id_(host->AllocateId(LifetimeOperationType::kValueConstruction)),
           host_(host) {}


### PR DESCRIPTION
**Changes**

- Added `proxy::facade_type` to align with the general design of STL.
- Added constraints on the polymorphic constructors / assignments of `proxy` that only allows "pointer" types.
- Updated unit tests and spec accordingly.