### PR TITLE
fix compilation error with clang 20

### DIFF
--- a/proxy.h
+++ b/proxy.h
@@ -13,6 +13,7 @@
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <new>
 #include <tuple>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
error: no member named 'launder' in namespace 'std'