### PR TITLE
Refactor `basic_facade_builder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Let's get started with the following "Hello World" example ([run](https://godbol
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 int main() {

--- a/benchmarks/proxy_invocation_benchmark_context.h
+++ b/benchmarks/proxy_invocation_benchmark_context.h
@@ -10,7 +10,7 @@ PRO_DEF_MEM_DISPATCH(MemFun, Fun);
 
 struct InvocationTestFacade : pro::facade_builder
     ::add_convention<MemFun, int() const>
-    ::support_view
+    ::support<pro::skills::as_view>
     ::build{};
 
 struct InvocationTestBase {

--- a/docs/allocate_proxy_shared.md
+++ b/docs/allocate_proxy_shared.md
@@ -46,7 +46,7 @@ The implementation of `strong-compact-ptr` may vary depending on the definition 
 
 struct RttiAware : pro::facade_builder
     ::support_copy<pro::constraint_level::nothrow>
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder.md
+++ b/docs/basic_facade_builder.md
@@ -64,12 +64,12 @@ For example, when defining a `Formattable` facade, the following two definitions
 ```cpp
 // (1) Recommended
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 // (2) Discouraged
 using Formattable = pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build;
 ```
 

--- a/docs/basic_facade_builder/support_format.md
+++ b/docs/basic_facade_builder/support_format.md
@@ -19,7 +19,7 @@ The member types `support_format` and `support_wformat` of `basic_facade_builder
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder/support_rtti.md
+++ b/docs/basic_facade_builder/support_rtti.md
@@ -25,8 +25,8 @@ The member types `support_rtti`, `support_indirect_rtti` and `support_direct_rtt
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
-    ::support_direct_rtti
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::direct_rtti>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder/support_rtti/proxy_cast.md
+++ b/docs/basic_facade_builder/support_rtti/proxy_cast.md
@@ -64,7 +64,7 @@ These functions are not visible to ordinary [unqualified](https://en.cppreferenc
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder/support_rtti/proxy_typeid.md
+++ b/docs/basic_facade_builder/support_rtti/proxy_typeid.md
@@ -23,7 +23,7 @@ These functions are not visible to ordinary [unqualified](https://en.cppreferenc
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder/support_view.md
+++ b/docs/basic_facade_builder/support_view.md
@@ -20,8 +20,8 @@ Let `p` be a value of type `proxy<F>`, `ptr` be the contained value of `p` (if a
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
-    ::support_view
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::as_view>
     ::build {};
 
 int main() {

--- a/docs/basic_facade_builder/support_weak.md
+++ b/docs/basic_facade_builder/support_weak.md
@@ -20,8 +20,8 @@ Let `p` be a value of type `proxy<F>`, `ptr` of type `P` be the contained value 
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
-    ::support_weak
+    ::support<pro::skills::format>
+    ::support<pro::skills::as_weak>
     ::build {};
 
 int main() {

--- a/docs/facade_aware_overload_t.md
+++ b/docs/facade_aware_overload_t.md
@@ -27,8 +27,8 @@ pro::proxy<F> operator+(const T& value, const pro::proxy_indirect_accessor<F>& r
     { return pro::make_proxy<F, T>(value + proxy_cast<const T&>(rhs)); }
 
 struct Addable : pro::facade_builder
-    ::support_rtti
-    ::support_format
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::format>
     ::add_convention<pro::operator_dispatch<"+">, pro::facade_aware_overload_t<BinaryOverload>>
     ::build {};
 

--- a/docs/make_proxy_shared.md
+++ b/docs/make_proxy_shared.md
@@ -39,8 +39,8 @@ Throws any exception thrown by allocation and the constructor of `T`.
 
 struct RttiAware : pro::facade_builder
     ::support_copy<pro::constraint_level::nothrow>
-    ::support_rtti
-    ::support_weak
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::as_weak>
     ::build {};
 
 int main() {

--- a/docs/weak_proxy.md
+++ b/docs/weak_proxy.md
@@ -31,7 +31,7 @@ Class template `weak_facade` is a [facade](facade.md) type for weak pointers (e.
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 int main() {

--- a/samples/allocate_proxy_shared.cpp
+++ b/samples/allocate_proxy_shared.cpp
@@ -9,7 +9,7 @@
 
 struct RttiAware : pro::facade_builder
     ::support_copy<pro::constraint_level::nothrow>
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_format.cpp
+++ b/samples/basic_facade_builder/support_format.cpp
@@ -8,7 +8,7 @@
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_rtti.cpp
+++ b/samples/basic_facade_builder/support_rtti.cpp
@@ -7,8 +7,8 @@
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
-    ::support_direct_rtti
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::direct_rtti>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_rtti/proxy_cast.cpp
+++ b/samples/basic_facade_builder/support_rtti/proxy_cast.cpp
@@ -7,7 +7,7 @@
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_rtti/proxy_typeid.cpp
+++ b/samples/basic_facade_builder/support_rtti/proxy_typeid.cpp
@@ -7,7 +7,7 @@
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_view.cpp
+++ b/samples/basic_facade_builder/support_view.cpp
@@ -7,8 +7,8 @@
 #include "proxy.h"
 
 struct RttiAware : pro::facade_builder
-    ::support_rtti
-    ::support_view
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::as_view>
     ::build {};
 
 int main() {

--- a/samples/basic_facade_builder/support_weak.cpp
+++ b/samples/basic_facade_builder/support_weak.cpp
@@ -7,8 +7,8 @@
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
-    ::support_weak
+    ::support<pro::skills::format>
+    ::support<pro::skills::as_weak>
     ::build {};
 
 int main() {

--- a/samples/facade_aware_overload_t.cpp
+++ b/samples/facade_aware_overload_t.cpp
@@ -15,8 +15,8 @@ pro::proxy<F> operator+(const T& value, const pro::proxy_indirect_accessor<F>& r
     { return pro::make_proxy<F, T>(value + proxy_cast<const T&>(rhs)); }
 
 struct Addable : pro::facade_builder
-    ::support_rtti
-    ::support_format
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::format>
     ::add_convention<pro::operator_dispatch<"+">, pro::facade_aware_overload_t<BinaryOverload>>
     ::build {};
 

--- a/samples/make_proxy_shared.cpp
+++ b/samples/make_proxy_shared.cpp
@@ -8,8 +8,8 @@
 
 struct RttiAware : pro::facade_builder
     ::support_copy<pro::constraint_level::nothrow>
-    ::support_rtti
-    ::support_weak
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::as_weak>
     ::build {};
 
 int main() {

--- a/samples/weak_proxy.cpp
+++ b/samples/weak_proxy.cpp
@@ -7,7 +7,7 @@
 #include "proxy.h"
 
 struct Formattable : pro::facade_builder
-    ::support_format
+    ::support<pro::skills::format>
     ::build {};
 
 int main() {

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -102,7 +102,7 @@ void SfinaeUnsafeIncrementImpl(T&& value) { ++value; }
 PRO_DEF_FREE_DISPATCH(FreeSfinaeUnsafeIncrement, SfinaeUnsafeIncrementImpl, Increment);
 
 struct SfinaeUnsafeFacade : pro::facade_builder
-    ::support_rtti
+    ::support<pro::skills::rtti>
     ::add_convention<FreeSfinaeUnsafeIncrement, void()>
     ::build {};
 
@@ -115,7 +115,7 @@ struct TestSharedStringable : pro::facade_builder
 
 struct TestWeakSharedStringable: pro::facade_builder
     ::add_facade<TestSharedStringable>
-    ::support_weak
+    ::support<pro::skills::as_weak>
     ::build {};
 
 static_assert(pro::proxiable<int*, TestSharedStringable>);

--- a/tests/proxy_format_tests.cpp
+++ b/tests/proxy_format_tests.cpp
@@ -12,8 +12,8 @@ static_assert(!std::is_default_constructible_v<std::formatter<pro::proxy_indirec
 static_assert(!std::is_default_constructible_v<std::formatter<pro::proxy_indirect_accessor<NonFormattable>, wchar_t>>);
 
 struct Formattable : pro::facade_builder
-    ::support_format
-    ::support_wformat
+    ::support<pro::skills::format>
+    ::support<pro::skills::wformat>
     ::build {};
 
 static_assert(std::is_default_constructible_v<std::formatter<pro::proxy_indirect_accessor<Formattable>, char>>);

--- a/tests/proxy_regression_tests.cpp
+++ b/tests/proxy_regression_tests.cpp
@@ -18,7 +18,7 @@ using SelfComparisonOverload = bool(const pro::proxy<F>& rhs) const noexcept;
 
 template <class T>
 struct Iterator : pro::facade_builder
-    ::support_direct_rtti
+    ::support<pro::skills::direct_rtti>
     ::restrict_layout<4 * sizeof(void*)>
     ::add_direct_convention<pro::operator_dispatch<"++">, void() noexcept>
     ::add_direct_convention<pro::operator_dispatch<"!=">, pro::facade_aware_overload_t<SelfComparisonOverload>>

--- a/tests/proxy_rtti_tests.cpp
+++ b/tests/proxy_rtti_tests.cpp
@@ -8,8 +8,8 @@
 namespace proxy_rtti_tests_details {
 
 struct TestFacade : pro::facade_builder
-    ::support_rtti
-    ::support_direct_rtti
+    ::support<pro::skills::rtti>
+    ::support<pro::skills::direct_rtti>
     ::build {};
 
 }  // namespace proxy_rtti_tests_details

--- a/tests/proxy_view_tests.cpp
+++ b/tests/proxy_view_tests.cpp
@@ -10,7 +10,7 @@ namespace proxy_view_tests_details {
 struct TestFacade : pro::facade_builder
     ::add_convention<pro::operator_dispatch<"+=">, void(int)>
     ::add_convention<utils::spec::FreeToString, std::string() const>
-    ::support_view
+    ::support<pro::skills::as_view>
     ::build {};
 
 template <class T>
@@ -79,7 +79,7 @@ TEST(ProxyViewTests, TestViewOfNonOwning) {
 TEST(ProxyViewTests, TestOverloadShadowing) {
   struct TestFacade : pro::facade_builder
       ::add_convention<pro::operator_dispatch<"()">, int(), int() const>
-      ::support_view
+      ::support<pro::skills::as_view>
       ::build {};
   struct TestImpl {
     int operator()() { return 0; }
@@ -97,7 +97,7 @@ TEST(ProxyViewTests, TestUpwardConversion_FromNull) {
   struct TestFacade1 : pro::facade_builder::build {};
   struct TestFacade2 : pro::facade_builder
       ::add_facade<TestFacade1, true>  // Supports upward conversion
-      ::support_view
+      ::support<pro::skills::as_view>
       ::build {};
   pro::proxy<TestFacade2> p1;
   pro::proxy_view<TestFacade2> p2 = p1;
@@ -114,7 +114,7 @@ TEST(ProxyViewTests, TestUpwardConversion_FromValue) {
   struct TestFacade2 : pro::facade_builder
       ::support_copy<pro::constraint_level::nontrivial>
       ::add_facade<TestFacade1, true>  // Supports upward conversion
-      ::support_view
+      ::support<pro::skills::as_view>
       ::build {};
   pro::proxy<TestFacade2> p1 = pro::make_proxy<TestFacade2>(123);
   pro::proxy_view<TestFacade2> p2 = p1;


### PR DESCRIPTION
*Changes*

- Added API `basic_facade_builder::support`.
- Refactoed APIs `basic_facade_builder::support_format`, `support_wformat`, `support_rtti`, `support_direct_rtti`, `support_indirect_rtti`, `support_view`, `support_weak` into types defined in namespace `pro::skills`.

*Spec will be updated separately*