### PR TITLE
Code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note: If you prefer the library to be consumed as a (C++20) module, refer to [C+
 
 ### Hello World (Stream Version)
 
-In the previous "Hello Word" example, we demonstrated how `proxy` could manage different types of objects and be formatted with `std::format`. While `std::format` is not the only option to print objects in C++, can we simply make `proxy` work with `std::cout`? The answer is "yes". The previous example is equivalent to the following implementation ([run](https://godbolt.org/z/q1b14WGff)):
+In the previous "Hello World" example, we demonstrated how `proxy` could manage different types of objects and be formatted with `std::format`. While `std::format` is not the only option to print objects in C++, can we simply make `proxy` work with `std::cout`? The answer is "yes". The previous example is equivalent to the following implementation ([run](https://godbolt.org/z/q1b14WGff)):
 
 ```cpp
 #include <iomanip>

--- a/cmake/msft_proxy4ModuleTargets.cmake
+++ b/cmake/msft_proxy4ModuleTargets.cmake
@@ -20,4 +20,7 @@ target_sources(msft_proxy4_module PUBLIC
     ${msft_proxy4_INCLUDE_DIR}/proxy/v4/proxy.ixx
 )
 target_compile_features(msft_proxy4_module PUBLIC cxx_std_20)
+target_compile_options(msft_proxy4_module PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
+)
 target_link_libraries(msft_proxy4_module PUBLIC msft_proxy4::proxy)

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -2444,7 +2444,7 @@ struct operator_dispatch;
         return std::forward<Arg>(arg) __VA_ARGS__           \
             std::forward<decltype(__self)>(__self);         \
       }                                                     \
-    )                 \
+    )                  \
   }
 #define ___PRO_RHS_OP_DISPATCH_IMPL(...)                                       \
   template <>                                                                  \

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -1730,9 +1730,8 @@ private:
   T&& value_;
 };
 
-inline constexpr std::size_t invalid_size =
-    std::numeric_limits<std::size_t>::max();
-inline constexpr constraint_level invalid_cl = static_cast<constraint_level>(
+constexpr std::size_t invalid_size = std::numeric_limits<std::size_t>::max();
+constexpr constraint_level invalid_cl = static_cast<constraint_level>(
     std::numeric_limits<std::underlying_type_t<constraint_level>>::min());
 consteval auto normalize(proxiable_ptr_constraints value) {
   if (value.max_size == invalid_size) {

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -1185,7 +1185,6 @@ private:
   void destroy()
     requires(F::constraints.destructibility != constraint_level::none)
   {
-    ___PRO4_DEBUG(std::ignore = &_symbol_guard;)
     if constexpr (F::constraints.destructibility != constraint_level::trivial) {
       if (meta_.has_value()) {
         proxy_invoke<true, details::destroy_dispatch,


### PR DESCRIPTION
**Changes**

- Fixed a typo in README
- Added /utf-8 when building modules with MSVC, similar to [fmt](https://github.com/fmtlib/fmt/blob/730fd4d9a7a9f5973a47c5c540becc71b62b8387/CMakeLists.txt#L372)
- Relaced `std::construct_at(this, ...)` and `std::destroy_at(this)` in `proxy` with private function calls. Otherwise, UB is inevitable (like `reset()`), although it passes unit tests.
- Removed null initialization form `details::invocation_meta` and `meta_ptr_indirect_impl` as they are no longer required.