### PR TITLE
Clean up macros

### DIFF
--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -12,7 +12,7 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 20
-        sudo apt install libc++-20-dev clang-format-20
+        sudo apt install -y libc++-20-dev clang-format-20
 
     - name: check compiler version
       run: |

--- a/include/proxy/proxy.h
+++ b/include/proxy/proxy.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY_
-#define _MSFT_PROXY_
+#ifndef MSFT_PROXY_PROXY_H_
+#define MSFT_PROXY_PROXY_H_
 
 #include "v4/proxy.h" // IWYU pragma: export
 
-#endif // _MSFT_PROXY_
+#endif // MSFT_PROXY_PROXY_H_

--- a/include/proxy/proxy_fmt.h
+++ b/include/proxy/proxy_fmt.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY_FMT_
-#define _MSFT_PROXY_FMT_
+#ifndef MSFT_PROXY_PROXY_FMT_H_
+#define MSFT_PROXY_PROXY_FMT_H_
 
 #include "v4/proxy_fmt.h" // IWYU pragma: export
 
-#endif // _MSFT_PROXY_FMT_
+#endif // MSFT_PROXY_PROXY_FMT_H_

--- a/include/proxy/proxy_macros.h
+++ b/include/proxy/proxy_macros.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY_MACROS_
-#define _MSFT_PROXY_MACROS_
+#ifndef MSFT_PROXY_PROXY_MACROS_H_
+#define MSFT_PROXY_PROXY_MACROS_H_
 
 #include "v4/proxy_macros.h" // IWYU pragma: export
 
-#endif // _MSFT_PROXY_MACROS_
+#endif // MSFT_PROXY_PROXY_MACROS_H_

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY4_
-#define _MSFT_PROXY4_
-
-#include "proxy_macros.h"
+#ifndef MSFT_PROXY_V4_PROXY_H_
+#define MSFT_PROXY_V4_PROXY_H_
 
 #include <bit>
 #include <cassert>
@@ -32,20 +30,22 @@
 #include <typeinfo>
 #endif // __cpp_rtti >= 199711L
 
+#include "proxy_macros.h"
+
 #if __has_cpp_attribute(msvc::no_unique_address)
-#define ___PRO_NO_UNIQUE_ADDRESS_ATTRIBUTE msvc::no_unique_address
+#define PROD_NO_UNIQUE_ADDRESS_ATTRIBUTE msvc::no_unique_address
 #elif __has_cpp_attribute(no_unique_address)
-#define ___PRO_NO_UNIQUE_ADDRESS_ATTRIBUTE no_unique_address
+#define PROD_NO_UNIQUE_ADDRESS_ATTRIBUTE no_unique_address
 #else
 #error Proxy requires C++20 attribute no_unique_address.
 #endif
 
-// `___PRO4_THROW` is used inside `proxy_fmt.h`,
+// `PRO4D_THROW` is used inside `proxy_fmt.h`,
 // hence it's not `#undef`-ed at the end.
 #if __cpp_exceptions >= 199711L
-#define ___PRO4_THROW(...) throw __VA_ARGS__
+#define PRO4D_THROW(...) throw __VA_ARGS__
 #else
-#define ___PRO4_THROW(...) std::abort()
+#define PRO4D_THROW(...) std::abort()
 #endif // __cpp_exceptions >= 199711L
 
 namespace pro::inline v4 {
@@ -132,7 +132,7 @@ concept facade = details::basic_facade_traits<F>::applicable;
 template <facade F>
 struct proxy_indirect_accessor;
 template <facade F>
-class ___PRO4_ENFORCE_EBO proxy;
+class PRO4D_ENFORCE_EBO proxy;
 
 namespace details {
 
@@ -543,7 +543,7 @@ struct refl_traits {
 
 struct copy_dispatch {
   template <class T, class F>
-  ___PRO4_STATIC_CALL(void, T&& self, proxy<F>& rhs) noexcept(
+  PRO4D_STATIC_CALL(void, T&& self, proxy<F>& rhs) noexcept(
       std::is_nothrow_constructible_v<std::decay_t<T>, T>)
     requires(std::is_constructible_v<std::decay_t<T>, T>)
   {
@@ -552,7 +552,7 @@ struct copy_dispatch {
 };
 struct destroy_dispatch {
   template <class T>
-  ___PRO4_STATIC_CALL(void, T& self) noexcept(std::is_nothrow_destructible_v<T>)
+  PRO4D_STATIC_CALL(void, T& self) noexcept(std::is_nothrow_destructible_v<T>)
     requires(std::is_destructible_v<T>)
   {
     std::destroy_at(&self);
@@ -570,7 +570,7 @@ template <class F, class D, class ONE, class OE, constraint_level C>
 using lifetime_meta_t = typename lifetime_meta_traits<F, D, ONE, OE, C>::type;
 
 template <class... As>
-class ___PRO4_ENFORCE_EBO composite_accessor_impl : public As... {
+class PRO4D_ENFORCE_EBO composite_accessor_impl : public As... {
   template <facade>
   friend class pro::v4::proxy;
   template <facade>
@@ -854,7 +854,7 @@ public:
   const T&& operator*() const&& noexcept { return std::move(value_); }
 
 private:
-  [[___PRO_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
+  [[PROD_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
   T value_;
 };
 
@@ -1129,13 +1129,13 @@ public:
 
 private:
   void initialize() {
-    ___PRO4_DEBUG(std::ignore = &_symbol_guard;)
+    PRO4D_DEBUG(std::ignore = &_symbol_guard;)
     meta_.reset();
   }
   void initialize(const proxy& rhs)
     requires(F::constraints.copyability != constraint_level::none)
   {
-    ___PRO4_DEBUG(std::ignore = &_symbol_guard;)
+    PRO4D_DEBUG(std::ignore = &_symbol_guard;)
     if (rhs.meta_.has_value()) {
       if constexpr (F::constraints.copyability == constraint_level::trivial) {
         std::ranges::uninitialized_copy(rhs.ptr_, ptr_);
@@ -1153,7 +1153,7 @@ private:
   void initialize(proxy&& rhs)
     requires(F::constraints.relocatability != constraint_level::none)
   {
-    ___PRO4_DEBUG(std::ignore = &_symbol_guard;)
+    PRO4D_DEBUG(std::ignore = &_symbol_guard;)
     if (rhs.meta_.has_value()) {
       if constexpr (F::constraints.relocatability ==
                     constraint_level::trivial) {
@@ -1172,7 +1172,7 @@ private:
   }
   template <class P, class... Args>
   constexpr P& initialize(Args&&... args) {
-    ___PRO4_DEBUG(std::ignore = &_symbol_guard;)
+    PRO4D_DEBUG(std::ignore = &_symbol_guard;)
     P& result = *std::construct_at(reinterpret_cast<P*>(ptr_),
                                    std::forward<Args>(args)...);
     if constexpr (proxiable<P, F>) {
@@ -1193,8 +1193,8 @@ private:
       }
     }
   }
-  ___PRO4_DEBUG(static inline void _symbol_guard(proxy& self,
-                                                 const proxy& cself) noexcept {
+  PRO4D_DEBUG(static inline void _symbol_guard(proxy& self,
+                                               const proxy& cself) noexcept {
     self.operator->();
     *self;
     *std::move(self);
@@ -1250,7 +1250,7 @@ public:
   explicit alloc_aware(const Alloc& alloc) noexcept : alloc(alloc) {}
   alloc_aware(const alloc_aware&) noexcept = default;
 
-  [[___PRO_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
+  [[PROD_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
   Alloc alloc;
 };
 template <class T>
@@ -1273,8 +1273,8 @@ protected:
 };
 
 template <class T, class Alloc>
-class ___PRO4_ENFORCE_EBO allocated_ptr : private alloc_aware<Alloc>,
-                                          public indirect_ptr<inplace_ptr<T>> {
+class PRO4D_ENFORCE_EBO allocated_ptr : private alloc_aware<Alloc>,
+                                        public indirect_ptr<inplace_ptr<T>> {
 public:
   template <class... Args>
   allocated_ptr(const Alloc& alloc, Args&&... args)
@@ -1300,8 +1300,8 @@ public:
 };
 
 template <class T, class Alloc>
-struct ___PRO4_ENFORCE_EBO compact_ptr_storage : alloc_aware<Alloc>,
-                                                 inplace_ptr<T> {
+struct PRO4D_ENFORCE_EBO compact_ptr_storage : alloc_aware<Alloc>,
+                                               inplace_ptr<T> {
   template <class... Args>
   explicit compact_ptr_storage(const Alloc& alloc, Args&&... args)
       : alloc_aware<Alloc>(alloc),
@@ -1335,7 +1335,7 @@ struct shared_compact_ptr_storage_base {
   std::atomic_long ref_count = 1;
 };
 template <class T, class Alloc>
-struct ___PRO4_ENFORCE_EBO shared_compact_ptr_storage
+struct PRO4D_ENFORCE_EBO shared_compact_ptr_storage
     : shared_compact_ptr_storage_base,
       alloc_aware<Alloc>,
       inplace_ptr<T> {
@@ -1684,10 +1684,10 @@ struct proxy_arg_traits<proxy_indirect_accessor<F>> : applicable_traits {};
 template <class T>
 concept non_proxy_arg = !proxy_arg_traits<std::decay_t<T>>::applicable;
 
-#define ___PRO_DEF_CAST_ACCESSOR(Q, SELF, ...)                                 \
+#define PROD_DEF_CAST_ACCESSOR(Q, SELF, ...)                                   \
   template <class __F, bool __IsDirect, class __D, class T>                    \
   struct accessor<__F, __IsDirect, __D, T() Q> {                               \
-    ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(operator T)                      \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(operator T)                        \
     explicit(Expl) operator T() Q {                                            \
       if constexpr (Nullable) {                                                \
         if (!SELF.has_value()) {                                               \
@@ -1699,15 +1699,15 @@ concept non_proxy_arg = !proxy_arg_traits<std::decay_t<T>>::applicable;
   }
 template <bool Expl, bool Nullable>
 struct cast_dispatch_base {
-  ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(
-      ___PRO_DEF_CAST_ACCESSOR,
+  PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(
+      PROD_DEF_CAST_ACCESSOR,
       operator typename overload_traits<__Os>::return_type)
 };
-#undef ___PRO_DEF_CAST_ACCESSOR
+#undef PROD_DEF_CAST_ACCESSOR
 
 struct upward_conversion_dispatch : cast_dispatch_base<false, true> {
   template <non_proxy_arg T>
-  ___PRO4_STATIC_CALL(T&&, T&& self) noexcept {
+  PRO4D_STATIC_CALL(T&&, T&& self) noexcept {
     return std::forward<T>(self);
   }
 };
@@ -2119,7 +2119,7 @@ namespace details {
 
 struct view_conversion_dispatch : cast_dispatch_base<false, true> {
   template <non_proxy_arg T>
-  ___PRO4_STATIC_CALL(auto, T& value) noexcept
+  PRO4D_STATIC_CALL(auto, T& value) noexcept
     requires(requires {
       { std::addressof(*value) } noexcept;
     })
@@ -2134,7 +2134,7 @@ using view_conversion_overload = proxy_view<F>() noexcept;
 
 struct weak_conversion_dispatch : cast_dispatch_base<false, true> {
   template <non_proxy_arg P>
-  ___PRO4_STATIC_CALL(auto, const P& self) noexcept
+  PRO4D_STATIC_CALL(auto, const P& self) noexcept
     requires(requires(const typename P::weak_type& w) {
       { w.lock() } noexcept -> std::same_as<P>;
     } && std::is_convertible_v<const P&, typename P::weak_type>)
@@ -2168,8 +2168,8 @@ struct format_dispatch {
   // std::formatter by std::is_default_constructible_v as per
   // [format.formatter.spec].
   template <class T, class CharT, class OutIt>
-  ___PRO4_STATIC_CALL(OutIt, const T& self, std::basic_string_view<CharT> spec,
-                      std::basic_format_context<OutIt, CharT>& fc)
+  PRO4D_STATIC_CALL(OutIt, const T& self, std::basic_string_view<CharT> spec,
+                    std::basic_format_context<OutIt, CharT>& fc)
     requires(
 #if __cpp_lib_format_ranges >= 202207L
         std::formattable<T, CharT>
@@ -2205,7 +2205,7 @@ struct proxy_cast_accessor_impl {
   friend T proxy_cast(_Self self) {
     static_assert(!std::is_rvalue_reference_v<T>);
     if (!access_proxy<F>(self).has_value()) [[unlikely]] {
-      ___PRO4_THROW(bad_proxy_cast{});
+      PRO4D_THROW(bad_proxy_cast{});
     }
     if constexpr (std::is_lvalue_reference_v<T>) {
       using U = std::remove_reference_t<T>;
@@ -2217,7 +2217,7 @@ struct proxy_cast_accessor_impl {
       proxy_invoke<IsDirect, D, O>(access_proxy<F>(std::forward<_Self>(self)),
                                    ctx);
       if (result == nullptr) [[unlikely]] {
-        ___PRO4_THROW(bad_proxy_cast{});
+        PRO4D_THROW(bad_proxy_cast{});
       }
       return *static_cast<U*>(result);
     } else {
@@ -2229,7 +2229,7 @@ struct proxy_cast_accessor_impl {
       proxy_invoke<IsDirect, D, O>(access_proxy<F>(std::forward<_Self>(self)),
                                    ctx);
       if (!result.has_value()) [[unlikely]] {
-        ___PRO4_THROW(bad_proxy_cast{});
+        PRO4D_THROW(bad_proxy_cast{});
       }
       return std::move(*result);
     }
@@ -2251,14 +2251,14 @@ struct proxy_cast_accessor_impl {
   }
 };
 
-#define ___PRO_DEF_PROXY_CAST_ACCESSOR(Q, ...)                                 \
+#define PROD_DEF_PROXY_CAST_ACCESSOR(Q, ...)                                   \
   template <class F, bool IsDirect, class D>                                   \
   struct accessor<F, IsDirect, D, void(proxy_cast_context) Q>                  \
       : proxy_cast_accessor_impl<F, IsDirect, D, void(proxy_cast_context) Q> { \
   }
 struct proxy_cast_dispatch {
   template <non_proxy_arg T>
-  ___PRO4_STATIC_CALL(void, T&& self, proxy_cast_context ctx) {
+  PRO4D_STATIC_CALL(void, T&& self, proxy_cast_context ctx) {
     if (typeid(T) == *ctx.type_ptr) [[likely]] {
       if (ctx.is_ref) {
         if constexpr (std::is_lvalue_reference_v<T>) {
@@ -2274,9 +2274,9 @@ struct proxy_cast_dispatch {
       }
     }
   }
-  ___PRO4_DEF_FREE_ACCESSOR_TEMPLATE(___PRO_DEF_PROXY_CAST_ACCESSOR)
+  PRO4D_DEF_FREE_ACCESSOR_TEMPLATE(PROD_DEF_PROXY_CAST_ACCESSOR)
 };
-#undef ___PRO_DEF_PROXY_CAST_ACCESSOR
+#undef PROD_DEF_PROXY_CAST_ACCESSOR
 
 struct proxy_typeid_reflector {
   template <class T>
@@ -2295,7 +2295,7 @@ struct proxy_typeid_reflector {
       const proxy_typeid_reflector& refl = proxy_reflect<IsDirect, R>(p);
       return *refl.info;
     }
-    ___PRO4_DEBUG(
+    PRO4D_DEBUG(
         accessor() noexcept { std::ignore = &_symbol_guard; }
 
         private : static inline const std::type_info& _symbol_guard(
@@ -2383,59 +2383,59 @@ using as_weak = typename FB::template add_direct_convention<
 template <details::sign Sign, bool Rhs = false>
 struct operator_dispatch;
 
-#define ___PRO_DEF_LHS_LEFT_OP_ACCESSOR(Q, SELF, ...)                          \
+#define PROD_DEF_LHS_LEFT_OP_ACCESSOR(Q, SELF, ...)                            \
   template <class __F, bool __IsDirect, class __D, class R>                    \
   struct accessor<__F, __IsDirect, __D, R() Q> {                               \
-    ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                     \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
     R __VA_ARGS__() Q { return proxy_invoke<__IsDirect, __D, R() Q>(SELF); }   \
   }
-#define ___PRO_DEF_LHS_ANY_OP_ACCESSOR(Q, SELF, ...)                           \
+#define PROD_DEF_LHS_ANY_OP_ACCESSOR(Q, SELF, ...)                             \
   template <class __F, bool __IsDirect, class __D, class R, class... Args>     \
   struct accessor<__F, __IsDirect, __D, R(Args...) Q> {                        \
-    ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                     \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
     R __VA_ARGS__(Args... args) Q {                                            \
       return proxy_invoke<__IsDirect, __D, R(Args...) Q>(                      \
           SELF, std::forward<Args>(args)...);                                  \
     }                                                                          \
   }
-#define ___PRO_DEF_LHS_UNARY_OP_ACCESSOR ___PRO_DEF_LHS_ANY_OP_ACCESSOR
-#define ___PRO_DEF_LHS_BINARY_OP_ACCESSOR ___PRO_DEF_LHS_ANY_OP_ACCESSOR
-#define ___PRO_DEF_LHS_ALL_OP_ACCESSOR ___PRO_DEF_LHS_ANY_OP_ACCESSOR
-#define ___PRO_LHS_LEFT_OP_DISPATCH_BODY_IMPL(...)                             \
+#define PROD_DEF_LHS_UNARY_OP_ACCESSOR PROD_DEF_LHS_ANY_OP_ACCESSOR
+#define PROD_DEF_LHS_BINARY_OP_ACCESSOR PROD_DEF_LHS_ANY_OP_ACCESSOR
+#define PROD_DEF_LHS_ALL_OP_ACCESSOR PROD_DEF_LHS_ANY_OP_ACCESSOR
+#define PROD_LHS_LEFT_OP_DISPATCH_BODY_IMPL(...)                               \
   template <details::non_proxy_arg T>                                          \
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self)                                \
-  ___PRO4_DIRECT_FUNC_IMPL(__VA_ARGS__ std::forward<T>(self))
-#define ___PRO_LHS_UNARY_OP_DISPATCH_BODY_IMPL(...)                            \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self)                                  \
+  PRO4D_DIRECT_FUNC_IMPL(__VA_ARGS__ std::forward<T>(self))
+#define PROD_LHS_UNARY_OP_DISPATCH_BODY_IMPL(...)                              \
   template <details::non_proxy_arg T>                                          \
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self)                                \
-  ___PRO4_DIRECT_FUNC_IMPL(                                                    \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self)                                  \
+  PRO4D_DIRECT_FUNC_IMPL(                                                      \
       __VA_ARGS__ std::forward<T>(self)) template <details::non_proxy_arg T>   \
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self, int)                           \
-  ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self) __VA_ARGS__)
-#define ___PRO_LHS_BINARY_OP_DISPATCH_BODY_IMPL(...)                           \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, int)                             \
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self) __VA_ARGS__)
+#define PROD_LHS_BINARY_OP_DISPATCH_BODY_IMPL(...)                             \
   template <details::non_proxy_arg T, class Arg>                               \
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
-  ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self)                               \
-                               __VA_ARGS__ std::forward<Arg>(arg))
-#define ___PRO_LHS_ALL_OP_DISPATCH_BODY_IMPL(...)                              \
-  ___PRO_LHS_LEFT_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                           \
-  ___PRO_LHS_BINARY_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)
-#define ___PRO_LHS_OP_DISPATCH_IMPL(TYPE, ...)                                 \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                       \
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)                                 \
+                             __VA_ARGS__ std::forward<Arg>(arg))
+#define PROD_LHS_ALL_OP_DISPATCH_BODY_IMPL(...)                                \
+  PROD_LHS_LEFT_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                             \
+  PROD_LHS_BINARY_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)
+#define PROD_LHS_OP_DISPATCH_IMPL(TYPE, ...)                                   \
   template <>                                                                  \
   struct operator_dispatch<#__VA_ARGS__, false> {                              \
-    ___PRO_LHS_##TYPE##_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                     \
-        ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(                                     \
-            ___PRO_DEF_LHS_##TYPE##_OP_ACCESSOR, operator __VA_ARGS__)         \
+    PROD_LHS_##TYPE##_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                       \
+        PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(                                       \
+            PROD_DEF_LHS_##TYPE##_OP_ACCESSOR, operator __VA_ARGS__)           \
   };
 
-#define ___PRO_DEF_RHS_OP_ACCESSOR(Q, NE, SELF_ARG, SELF, ...)                 \
+#define PROD_DEF_RHS_OP_ACCESSOR(Q, NE, SELF_ARG, SELF, ...)                   \
   template <class __F, bool __IsDirect, class __D, class R, class Arg>         \
   struct accessor<__F, __IsDirect, __D, R(Arg) Q> {                            \
     friend R operator __VA_ARGS__(Arg arg, SELF_ARG) NE {                      \
       return proxy_invoke<__IsDirect, __D, R(Arg) Q>(SELF,                     \
                                                      std::forward<Arg>(arg));  \
     }                                                                          \
-    ___PRO4_DEBUG(                                          \
+    PRO4D_DEBUG(                                          \
       accessor() noexcept { std::ignore = &_symbol_guard; } \
                                                             \
     private:                                                \
@@ -2443,31 +2443,31 @@ struct operator_dispatch;
         return std::forward<Arg>(arg) __VA_ARGS__           \
             std::forward<decltype(__self)>(__self);         \
       }                                                     \
-    )                  \
+    )                    \
   }
-#define ___PRO_RHS_OP_DISPATCH_IMPL(...)                                       \
+#define PROD_RHS_OP_DISPATCH_IMPL(...)                                         \
   template <>                                                                  \
   struct operator_dispatch<#__VA_ARGS__, true> {                               \
     template <details::non_proxy_arg T, class Arg>                             \
-    ___PRO4_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                   \
-    ___PRO4_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                            \
-                                 __VA_ARGS__ std::forward<T>(self))            \
-        ___PRO4_DEF_FREE_ACCESSOR_TEMPLATE(___PRO_DEF_RHS_OP_ACCESSOR,         \
-                                           __VA_ARGS__)                        \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                              \
+                               __VA_ARGS__ std::forward<T>(self))              \
+        PRO4D_DEF_FREE_ACCESSOR_TEMPLATE(PROD_DEF_RHS_OP_ACCESSOR,             \
+                                         __VA_ARGS__)                          \
   };
 
-#define ___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL(...)                           \
-  ___PRO_LHS_OP_DISPATCH_IMPL(ALL, __VA_ARGS__)                                \
-  ___PRO_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
+#define PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL(...)                             \
+  PROD_LHS_OP_DISPATCH_IMPL(ALL, __VA_ARGS__)                                  \
+  PROD_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
 
-#define ___PRO_BINARY_OP_DISPATCH_IMPL(...)                                    \
-  ___PRO_LHS_OP_DISPATCH_IMPL(BINARY, __VA_ARGS__)                             \
-  ___PRO_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
+#define PROD_BINARY_OP_DISPATCH_IMPL(...)                                      \
+  PROD_LHS_OP_DISPATCH_IMPL(BINARY, __VA_ARGS__)                               \
+  PROD_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
 
-#define ___PRO_DEF_LHS_ASSIGNMENT_OP_ACCESSOR(Q, SELF, ...)                    \
+#define PROD_DEF_LHS_ASSIGNMENT_OP_ACCESSOR(Q, SELF, ...)                      \
   template <class __F, bool __IsDirect, class __D, class R, class Arg>         \
   struct accessor<__F, __IsDirect, __D, R(Arg) Q> {                            \
-    ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                     \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
     decltype(auto) __VA_ARGS__(Arg arg) Q {                                    \
       proxy_invoke<__IsDirect, __D, R(Arg) Q>(SELF, std::forward<Arg>(arg));   \
       if constexpr (__IsDirect) {                                              \
@@ -2477,126 +2477,124 @@ struct operator_dispatch;
       }                                                                        \
     }                                                                          \
   }
-#define ___PRO_DEF_RHS_ASSIGNMENT_OP_ACCESSOR(Q, NE, SELF_ARG, SELF, ...)          \
+#define PROD_DEF_RHS_ASSIGNMENT_OP_ACCESSOR(Q, NE, SELF_ARG, SELF, ...)            \
   template <class __F, bool __IsDirect, class __D, class R, class Arg>             \
   struct accessor<__F, __IsDirect, __D, R(Arg&) Q> {                               \
     friend Arg& operator __VA_ARGS__(Arg & arg, SELF_ARG) NE {                     \
       proxy_invoke<__IsDirect, __D, R(Arg&) Q>(SELF, arg);                         \
       return arg;                                                                  \
     }                                                                              \
-    ___PRO4_DEBUG(                                                                 \
+    PRO4D_DEBUG(                                                                   \
         accessor() noexcept { std::ignore = &_symbol_guard; }                      \
                                                                                    \
         private : static inline Arg& _symbol_guard(Arg& arg, SELF_ARG)             \
             NE { return arg __VA_ARGS__ std::forward<decltype(__self)>(            \
                      __self); }) \
   }
-#define ___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(...)                                \
+#define PROD_ASSIGNMENT_OP_DISPATCH_IMPL(...)                                  \
   template <>                                                                  \
   struct operator_dispatch<#__VA_ARGS__, false> {                              \
     template <details::non_proxy_arg T, class Arg>                             \
-    ___PRO4_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                   \
-    ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self)                             \
-                                 __VA_ARGS__ std::forward<Arg>(arg))           \
-        ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(                                     \
-            ___PRO_DEF_LHS_ASSIGNMENT_OP_ACCESSOR, operator __VA_ARGS__)       \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)                               \
+                               __VA_ARGS__ std::forward<Arg>(arg))             \
+        PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(                                       \
+            PROD_DEF_LHS_ASSIGNMENT_OP_ACCESSOR, operator __VA_ARGS__)         \
   };                                                                           \
   template <>                                                                  \
   struct operator_dispatch<#__VA_ARGS__, true> {                               \
     template <details::non_proxy_arg T, class Arg>                             \
-    ___PRO4_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                   \
-    ___PRO4_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                            \
-                                 __VA_ARGS__ std::forward<T>(self))            \
-        ___PRO4_DEF_FREE_ACCESSOR_TEMPLATE(                                    \
-            ___PRO_DEF_RHS_ASSIGNMENT_OP_ACCESSOR, __VA_ARGS__)                \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                              \
+                               __VA_ARGS__ std::forward<T>(self))              \
+        PRO4D_DEF_FREE_ACCESSOR_TEMPLATE(PROD_DEF_RHS_ASSIGNMENT_OP_ACCESSOR,  \
+                                         __VA_ARGS__)                          \
   };
 
-___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL(+)
-___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL(-)
-___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL(*)
-___PRO_BINARY_OP_DISPATCH_IMPL(/)
-___PRO_BINARY_OP_DISPATCH_IMPL(%)
-___PRO_LHS_OP_DISPATCH_IMPL(UNARY, ++)
-___PRO_LHS_OP_DISPATCH_IMPL(UNARY, --)
-___PRO_BINARY_OP_DISPATCH_IMPL(==)
-___PRO_BINARY_OP_DISPATCH_IMPL(!=)
-___PRO_BINARY_OP_DISPATCH_IMPL(>)
-___PRO_BINARY_OP_DISPATCH_IMPL(<)
-___PRO_BINARY_OP_DISPATCH_IMPL(>=)
-___PRO_BINARY_OP_DISPATCH_IMPL(<=)
-___PRO_BINARY_OP_DISPATCH_IMPL(<=>)
-___PRO_LHS_OP_DISPATCH_IMPL(LEFT, !)
-___PRO_BINARY_OP_DISPATCH_IMPL(&&)
-___PRO_BINARY_OP_DISPATCH_IMPL(||)
-___PRO_LHS_OP_DISPATCH_IMPL(LEFT, ~)
-___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL(&)
-___PRO_BINARY_OP_DISPATCH_IMPL(|)
-___PRO_BINARY_OP_DISPATCH_IMPL(^)
-___PRO_BINARY_OP_DISPATCH_IMPL(<<)
-___PRO_BINARY_OP_DISPATCH_IMPL(>>)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(+=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(-=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(*=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(/=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(&=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(|=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(^=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(<<=)
-___PRO_ASSIGNMENT_OP_DISPATCH_IMPL(>>=)
-___PRO_BINARY_OP_DISPATCH_IMPL(, )
-___PRO_BINARY_OP_DISPATCH_IMPL(->*)
+PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL(+)
+PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL(-)
+PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL(*)
+PROD_BINARY_OP_DISPATCH_IMPL(/)
+PROD_BINARY_OP_DISPATCH_IMPL(%)
+PROD_LHS_OP_DISPATCH_IMPL(UNARY, ++)
+PROD_LHS_OP_DISPATCH_IMPL(UNARY, --)
+PROD_BINARY_OP_DISPATCH_IMPL(==)
+PROD_BINARY_OP_DISPATCH_IMPL(!=)
+PROD_BINARY_OP_DISPATCH_IMPL(>)
+PROD_BINARY_OP_DISPATCH_IMPL(<)
+PROD_BINARY_OP_DISPATCH_IMPL(>=)
+PROD_BINARY_OP_DISPATCH_IMPL(<=)
+PROD_BINARY_OP_DISPATCH_IMPL(<=>)
+PROD_LHS_OP_DISPATCH_IMPL(LEFT, !)
+PROD_BINARY_OP_DISPATCH_IMPL(&&)
+PROD_BINARY_OP_DISPATCH_IMPL(||)
+PROD_LHS_OP_DISPATCH_IMPL(LEFT, ~)
+PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL(&)
+PROD_BINARY_OP_DISPATCH_IMPL(|)
+PROD_BINARY_OP_DISPATCH_IMPL(^)
+PROD_BINARY_OP_DISPATCH_IMPL(<<)
+PROD_BINARY_OP_DISPATCH_IMPL(>>)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(+=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(-=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(*=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(/=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(&=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(|=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(^=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(<<=)
+PROD_ASSIGNMENT_OP_DISPATCH_IMPL(>>=)
+PROD_BINARY_OP_DISPATCH_IMPL(, )
+PROD_BINARY_OP_DISPATCH_IMPL(->*)
 
 template <>
 struct operator_dispatch<"()", false> {
   template <details::non_proxy_arg T, class... Args>
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
-  ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self)(std::forward<Args>(args)...))
-      ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(
-          ___PRO_DEF_LHS_ANY_OP_ACCESSOR, operator())
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)(std::forward<Args>(args)...))
+      PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(PROD_DEF_LHS_ANY_OP_ACCESSOR, operator())
 };
 template <>
 struct operator_dispatch<"[]", false> {
 #if __cpp_multidimensional_subscript >= 202110L
   template <details::non_proxy_arg T, class... Args>
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
-  ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Args>(args)...])
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Args>(args)...])
 #else
   template <details::non_proxy_arg T, class Arg>
-  ___PRO4_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)
-  ___PRO4_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Arg>(arg)])
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Arg>(arg)])
 #endif // __cpp_multidimensional_subscript >= 202110L
-      ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(
-          ___PRO_DEF_LHS_ANY_OP_ACCESSOR, operator[])
+      PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(PROD_DEF_LHS_ANY_OP_ACCESSOR, operator[])
 };
 
-#undef ___PRO_ASSIGNMENT_OP_DISPATCH_IMPL
-#undef ___PRO_DEF_RHS_ASSIGNMENT_OP_ACCESSOR
-#undef ___PRO_DEF_LHS_ASSIGNMENT_OP_ACCESSOR
-#undef ___PRO_BINARY_OP_DISPATCH_IMPL
-#undef ___PRO_EXTENDED_BINARY_OP_DISPATCH_IMPL
-#undef ___PRO_RHS_OP_DISPATCH_IMPL
-#undef ___PRO_DEF_RHS_OP_ACCESSOR
-#undef ___PRO_LHS_OP_DISPATCH_IMPL
-#undef ___PRO_LHS_ALL_OP_DISPATCH_BODY_IMPL
-#undef ___PRO_LHS_BINARY_OP_DISPATCH_BODY_IMPL
-#undef ___PRO_LHS_UNARY_OP_DISPATCH_BODY_IMPL
-#undef ___PRO_LHS_LEFT_OP_DISPATCH_BODY_IMPL
-#undef ___PRO_DEF_LHS_ALL_OP_ACCESSOR
-#undef ___PRO_DEF_LHS_BINARY_OP_ACCESSOR
-#undef ___PRO_DEF_LHS_UNARY_OP_ACCESSOR
-#undef ___PRO_DEF_LHS_ANY_OP_ACCESSOR
-#undef ___PRO_DEF_LHS_LEFT_OP_ACCESSOR
+#undef PROD_ASSIGNMENT_OP_DISPATCH_IMPL
+#undef PROD_DEF_RHS_ASSIGNMENT_OP_ACCESSOR
+#undef PROD_DEF_LHS_ASSIGNMENT_OP_ACCESSOR
+#undef PROD_BINARY_OP_DISPATCH_IMPL
+#undef PROD_EXTENDED_BINARY_OP_DISPATCH_IMPL
+#undef PROD_RHS_OP_DISPATCH_IMPL
+#undef PROD_DEF_RHS_OP_ACCESSOR
+#undef PROD_LHS_OP_DISPATCH_IMPL
+#undef PROD_LHS_ALL_OP_DISPATCH_BODY_IMPL
+#undef PROD_LHS_BINARY_OP_DISPATCH_BODY_IMPL
+#undef PROD_LHS_UNARY_OP_DISPATCH_BODY_IMPL
+#undef PROD_LHS_LEFT_OP_DISPATCH_BODY_IMPL
+#undef PROD_DEF_LHS_ALL_OP_ACCESSOR
+#undef PROD_DEF_LHS_BINARY_OP_ACCESSOR
+#undef PROD_DEF_LHS_UNARY_OP_ACCESSOR
+#undef PROD_DEF_LHS_ANY_OP_ACCESSOR
+#undef PROD_DEF_LHS_LEFT_OP_ACCESSOR
 
 struct implicit_conversion_dispatch
     : details::cast_dispatch_base<false, false> {
   template <details::non_proxy_arg T>
-  ___PRO4_STATIC_CALL(T&&, T&& self) noexcept {
+  PRO4D_STATIC_CALL(T&&, T&& self) noexcept {
     return std::forward<T>(self);
   }
 };
 struct explicit_conversion_dispatch : details::cast_dispatch_base<true, false> {
   template <details::non_proxy_arg T>
-  ___PRO4_STATIC_CALL(auto, T&& self) noexcept {
+  PRO4D_STATIC_CALL(auto, T&& self) noexcept {
     return details::explicit_conversion_adapter<T>{std::forward<T>(self)};
   }
 };
@@ -2613,8 +2611,8 @@ template <class D>
 struct weak_dispatch : D {
   using D::operator();
   template <class... Args>
-  [[noreturn]] ___PRO4_STATIC_CALL(details::wildcard, Args&&...) {
-    ___PRO4_THROW(not_implemented{});
+  [[noreturn]] PRO4D_STATIC_CALL(details::wildcard, Args&&...) {
+    PRO4D_THROW(not_implemented{});
   }
 };
 
@@ -2643,7 +2641,7 @@ struct formatter<pro::v4::proxy_indirect_accessor<F>, CharT> {
                basic_format_context<OutIt, CharT>& fc) const {
     auto& p = pro::v4::access_proxy<F>(ia);
     if (!p.has_value()) [[unlikely]] {
-      ___PRO4_THROW(format_error{"null proxy"});
+      PRO4D_THROW(format_error{"null proxy"});
     }
     return pro::v4::proxy_invoke<false, pro::v4::details::format_dispatch,
                                  pro::v4::details::format_overload_t<CharT>>(
@@ -2657,6 +2655,6 @@ private:
 } // namespace std
 #endif // __STDC_HOSTED__ && __has_include(<format>)
 
-#undef ___PRO_NO_UNIQUE_ADDRESS_ATTRIBUTE
+#undef PROD_NO_UNIQUE_ADDRESS_ATTRIBUTE
 
-#endif // _MSFT_PROXY4_
+#endif // MSFT_PROXY_V4_PROXY_H_

--- a/include/proxy/v4/proxy_fmt.h
+++ b/include/proxy/v4/proxy_fmt.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY4_FMT_
-#define _MSFT_PROXY4_FMT_
+#ifndef MSFT_PROXY_V4_PROXY_FMT_H_
+#define MSFT_PROXY_V4_PROXY_FMT_H_
 
 #include <string_view>
 #include <type_traits>
@@ -39,8 +39,8 @@ using fmt_format_overload_t = typename fmt_format_overload_traits<CharT>::type;
 
 struct fmt_format_dispatch {
   template <class T, class CharT, class FormatContext>
-  ___PRO4_STATIC_CALL(auto, const T& self, std::basic_string_view<CharT> spec,
-                      FormatContext& fc)
+  PRO4D_STATIC_CALL(auto, const T& self, std::basic_string_view<CharT> spec,
+                    FormatContext& fc)
     requires(std::is_default_constructible_v<fmt::formatter<T, CharT>>)
   {
     fmt::formatter<T, CharT> impl;
@@ -91,7 +91,7 @@ struct formatter<pro::v4::proxy_indirect_accessor<F>, CharT> {
               FormatContext& fc) const -> typename FormatContext::iterator {
     auto& p = pro::v4::access_proxy<F>(ia);
     if (!p.has_value()) [[unlikely]] {
-      ___PRO4_THROW(format_error{"null proxy"});
+      PRO4D_THROW(format_error{"null proxy"});
     }
     return pro::v4::proxy_invoke<
         false, pro::v4::details::fmt_format_dispatch,
@@ -104,4 +104,4 @@ private:
 
 } // namespace fmt
 
-#endif // _MSFT_PROXY4_FMT_
+#endif // MSFT_PROXY_V4_PROXY_FMT_H_

--- a/include/proxy/v4/proxy_macros.h
+++ b/include/proxy/v4/proxy_macros.h
@@ -1,39 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef _MSFT_PROXY4_MACROS_
-#define _MSFT_PROXY4_MACROS_
+#ifndef MSFT_PROXY_V4_PROXY_MACROS_H_
+#define MSFT_PROXY_V4_PROXY_MACROS_H_
 
 #if __cpp_static_call_operator >= 202207L
-#define ___PRO4_STATIC_CALL(__R, ...) static __R operator()(__VA_ARGS__)
+#define PRO4D_STATIC_CALL(__R, ...) static __R operator()(__VA_ARGS__)
 #else
-#define ___PRO4_STATIC_CALL(__R, ...) __R operator()(__VA_ARGS__) const
+#define PRO4D_STATIC_CALL(__R, ...) __R operator()(__VA_ARGS__) const
 #endif // __cpp_static_call_operator >= 202207L
 
 #ifdef _MSC_VER
-#define ___PRO4_ENFORCE_EBO __declspec(empty_bases)
+#define PRO4D_ENFORCE_EBO __declspec(empty_bases)
 #else
-#define ___PRO4_ENFORCE_EBO
+#define PRO4D_ENFORCE_EBO
 #endif // _MSC_VER
 
 #ifdef NDEBUG
-#define ___PRO4_DEBUG(...)
+#define PRO4D_DEBUG(...)
 #else
-#define ___PRO4_DEBUG(...) __VA_ARGS__
+#define PRO4D_DEBUG(...) __VA_ARGS__
 #endif // NDEBUG
 
 #define __msft_lib_proxy4 202506L
 
-#define ___PRO4_DIRECT_FUNC_IMPL(...)                                          \
+#define PRO4D_DIRECT_FUNC_IMPL(...)                                            \
   noexcept(noexcept(__VA_ARGS__))                                              \
     requires(requires { __VA_ARGS__; })                                        \
   {                                                                            \
     return __VA_ARGS__;                                                        \
   }
 
-#define ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(__MACRO, ...)                        \
+#define PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(__MACRO, ...)                          \
   template <class __F, bool __IsDirect, class __D, class... __Os>              \
-  struct ___PRO4_ENFORCE_EBO accessor {                                        \
+  struct PRO4D_ENFORCE_EBO accessor {                                          \
     accessor() = delete;                                                       \
   };                                                                           \
   template <class __F, bool __IsDirect, class __D, class... __Os>              \
@@ -61,10 +61,10 @@
   __MACRO(const&& noexcept, ::pro::v4::access_proxy<__F>(::std::move(*this)),  \
           __VA_ARGS__);
 
-#define ___PRO4_ADL_ARG ::pro::v4::details::adl_accessor_arg_t<__F, __IsDirect>
-#define ___PRO4_DEF_FREE_ACCESSOR_TEMPLATE(__MACRO, ...)                       \
+#define PRO4D_ADL_ARG ::pro::v4::details::adl_accessor_arg_t<__F, __IsDirect>
+#define PRO4D_DEF_FREE_ACCESSOR_TEMPLATE(__MACRO, ...)                         \
   template <class __F, bool __IsDirect, class __D, class... __Os>              \
-  struct ___PRO4_ENFORCE_EBO accessor {                                        \
+  struct PRO4D_ENFORCE_EBO accessor {                                          \
     accessor() = delete;                                                       \
   };                                                                           \
   template <class __F, bool __IsDirect, class __D, class... __Os>              \
@@ -74,83 +74,83 @@
          ...))                                                                 \
   struct accessor<__F, __IsDirect, __D, __Os...>                               \
       : accessor<__F, __IsDirect, __D, __Os>... {};                            \
-  __MACRO(, , ___PRO4_ADL_ARG& __self, ::pro::v4::access_proxy<__F>(__self),   \
+  __MACRO(, , PRO4D_ADL_ARG& __self, ::pro::v4::access_proxy<__F>(__self),     \
           __VA_ARGS__);                                                        \
-  __MACRO(noexcept, noexcept, ___PRO4_ADL_ARG& __self,                         \
+  __MACRO(noexcept, noexcept, PRO4D_ADL_ARG& __self,                           \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
-  __MACRO(&, , ___PRO4_ADL_ARG& __self, ::pro::v4::access_proxy<__F>(__self),  \
+  __MACRO(&, , PRO4D_ADL_ARG& __self, ::pro::v4::access_proxy<__F>(__self),    \
           __VA_ARGS__);                                                        \
-  __MACRO(& noexcept, noexcept, ___PRO4_ADL_ARG& __self,                       \
+  __MACRO(& noexcept, noexcept, PRO4D_ADL_ARG& __self,                         \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
-  __MACRO(&&, , ___PRO4_ADL_ARG&& __self,                                      \
+  __MACRO(&&, , PRO4D_ADL_ARG&& __self,                                        \
           ::pro::v4::access_proxy<__F>(                                        \
               ::std::forward<decltype(__self)>(__self)),                       \
           __VA_ARGS__);                                                        \
-  __MACRO(&& noexcept, noexcept, ___PRO4_ADL_ARG&& __self,                     \
+  __MACRO(&& noexcept, noexcept, PRO4D_ADL_ARG&& __self,                       \
           ::pro::v4::access_proxy<__F>(                                        \
               ::std::forward<decltype(__self)>(__self)),                       \
           __VA_ARGS__);                                                        \
-  __MACRO(const, , const ___PRO4_ADL_ARG& __self,                              \
+  __MACRO(const, , const PRO4D_ADL_ARG& __self,                                \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
-  __MACRO(const noexcept, noexcept, const ___PRO4_ADL_ARG& __self,             \
+  __MACRO(const noexcept, noexcept, const PRO4D_ADL_ARG& __self,               \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
-  __MACRO(const&, , const ___PRO4_ADL_ARG& __self,                             \
+  __MACRO(const&, , const PRO4D_ADL_ARG& __self,                               \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
-  __MACRO(const& noexcept, noexcept, const ___PRO4_ADL_ARG& __self,            \
+  __MACRO(const& noexcept, noexcept, const PRO4D_ADL_ARG& __self,              \
           ::pro::v4::access_proxy<__F>(__self), __VA_ARGS__);                  \
   __MACRO(                                                                     \
-      const&&, , const ___PRO4_ADL_ARG&& __self,                               \
+      const&&, , const PRO4D_ADL_ARG&& __self,                                 \
       ::pro::v4::access_proxy<__F>(::std::forward<decltype(__self)>(__self)),  \
       __VA_ARGS__);                                                            \
   __MACRO(                                                                     \
-      const&& noexcept, noexcept, const ___PRO4_ADL_ARG&& __self,              \
+      const&& noexcept, noexcept, const PRO4D_ADL_ARG&& __self,                \
       ::pro::v4::access_proxy<__F>(::std::forward<decltype(__self)>(__self)),  \
       __VA_ARGS__);
 
-#define ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(...)                         \
-  ___PRO4_DEBUG(accessor() noexcept { ::std::ignore = &accessor::__VA_ARGS__; })
+#define PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(...)                           \
+  PRO4D_DEBUG(accessor() noexcept { ::std::ignore = &accessor::__VA_ARGS__; })
 
-#define ___PRO4_EXPAND_IMPL(__X) __X
+#define PRO4D_EXPAND_IMPL(__X) __X
 
-#define ___PRO4_EXPAND_MACRO_IMPL(__MACRO, __1, __2, __3, __NAME, ...)         \
+#define PRO4D_EXPAND_MACRO_IMPL(__MACRO, __1, __2, __3, __NAME, ...)           \
   __MACRO##_##__NAME
-#define ___PRO4_EXPAND_MACRO(__MACRO, ...)                                     \
-  ___PRO4_EXPAND_IMPL(                                                         \
-      ___PRO4_EXPAND_MACRO_IMPL(__MACRO, __VA_ARGS__, 3, 2)(__VA_ARGS__))
+#define PRO4D_EXPAND_MACRO(__MACRO, ...)                                       \
+  PRO4D_EXPAND_IMPL(                                                           \
+      PRO4D_EXPAND_MACRO_IMPL(__MACRO, __VA_ARGS__, 3, 2)(__VA_ARGS__))
 
-#define ___PRO4_DEF_MEM_ACCESSOR(__Q, __SELF, ...)                             \
+#define PRO4D_DEF_MEM_ACCESSOR(__Q, __SELF, ...)                               \
   template <class __F, bool __IsDirect, class __D, class __R, class... __Args> \
   struct accessor<__F, __IsDirect, __D, __R(__Args...) __Q> {                  \
-    ___PRO4_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                     \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
     __R __VA_ARGS__(__Args... __args) __Q {                                    \
       return ::pro::v4::proxy_invoke<__IsDirect, __D, __R(__Args...) __Q>(     \
           __SELF, ::std::forward<__Args>(__args)...);                          \
     }                                                                          \
   }
-#define ___PRO4_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, __TTYPE)        \
+#define PRO4D_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, __TTYPE)          \
   struct __NAME {                                                              \
     template <__TTYPE __T, class... __Args>                                    \
-    ___PRO4_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)      \
-    ___PRO4_DIRECT_FUNC_IMPL(                                                  \
+    PRO4D_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)        \
+    PRO4D_DIRECT_FUNC_IMPL(                                                    \
         ::std::forward<__T>(__self).__FUNC(::std::forward<__Args>(__args)...)) \
-        ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(___PRO4_DEF_MEM_ACCESSOR, __FNAME)   \
+        PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(PRO4D_DEF_MEM_ACCESSOR, __FNAME)       \
   }
-#define ___PRO4_DEF_MEM_DISPATCH_2(__NAME, __FUNC)                             \
-  ___PRO4_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FUNC,                        \
-                                ::pro::v4::details::non_proxy_arg)
-#define ___PRO4_DEF_MEM_DISPATCH_3(__NAME, __FUNC, __FNAME)                    \
-  ___PRO4_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, class)
+#define PRO4D_DEF_MEM_DISPATCH_2(__NAME, __FUNC)                               \
+  PRO4D_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FUNC,                          \
+                              ::pro::v4::details::non_proxy_arg)
+#define PRO4D_DEF_MEM_DISPATCH_3(__NAME, __FUNC, __FNAME)                      \
+  PRO4D_DEF_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, class)
 #define PRO4_DEF_MEM_DISPATCH(__NAME, ...)                                     \
-  ___PRO4_EXPAND_MACRO(___PRO4_DEF_MEM_DISPATCH, __NAME, __VA_ARGS__)
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_MEM_DISPATCH, __NAME, __VA_ARGS__)
 
-#define ___PRO4_DEF_FREE_ACCESSOR(__Q, __NE, __SELF_ARG, __SELF, ...)          \
+#define PRO4D_DEF_FREE_ACCESSOR(__Q, __NE, __SELF_ARG, __SELF, ...)            \
   template <class __F, bool __IsDirect, class __D, class __R, class... __Args> \
   struct accessor<__F, __IsDirect, __D, __R(__Args...) __Q> {                  \
     friend __R __VA_ARGS__(__SELF_ARG, __Args... __args) __NE {                \
       return ::pro::v4::proxy_invoke<__IsDirect, __D, __R(__Args...) __Q>(     \
           __SELF, ::std::forward<__Args>(__args)...);                          \
     }                                                                          \
-    ___PRO4_DEBUG(                                                         \
+    PRO4D_DEBUG(                                                         \
       accessor() noexcept { ::std::ignore = &_symbol_guard; }              \
                                                                            \
     private:                                                               \
@@ -158,43 +158,43 @@
         return __VA_ARGS__(::std::forward<decltype(__self)>(__self),       \
             ::std::forward<__Args>(__args)...);                            \
       }                                                                    \
-    )   \
+    )     \
   }
-#define ___PRO4_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, __TTYPE)       \
+#define PRO4D_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, __TTYPE)         \
   struct __NAME {                                                              \
     template <__TTYPE __T, class... __Args>                                    \
-    ___PRO4_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)      \
-    ___PRO4_DIRECT_FUNC_IMPL(__FUNC(::std::forward<__T>(__self),               \
-                                    ::std::forward<__Args>(__args)...))        \
-        ___PRO4_DEF_FREE_ACCESSOR_TEMPLATE(___PRO4_DEF_FREE_ACCESSOR, __FNAME) \
+    PRO4D_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)        \
+    PRO4D_DIRECT_FUNC_IMPL(__FUNC(::std::forward<__T>(__self),                 \
+                                  ::std::forward<__Args>(__args)...))          \
+        PRO4D_DEF_FREE_ACCESSOR_TEMPLATE(PRO4D_DEF_FREE_ACCESSOR, __FNAME)     \
   }
-#define ___PRO4_DEF_FREE_DISPATCH_2(__NAME, __FUNC)                            \
-  ___PRO4_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FUNC,                       \
-                                 ::pro::v4::details::non_proxy_arg)
-#define ___PRO4_DEF_FREE_DISPATCH_3(__NAME, __FUNC, __FNAME)                   \
-  ___PRO4_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, class)
+#define PRO4D_DEF_FREE_DISPATCH_2(__NAME, __FUNC)                              \
+  PRO4D_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FUNC,                         \
+                               ::pro::v4::details::non_proxy_arg)
+#define PRO4D_DEF_FREE_DISPATCH_3(__NAME, __FUNC, __FNAME)                     \
+  PRO4D_DEF_FREE_DISPATCH_IMPL(__NAME, __FUNC, __FNAME, class)
 #define PRO4_DEF_FREE_DISPATCH(__NAME, ...)                                    \
-  ___PRO4_EXPAND_MACRO(___PRO4_DEF_FREE_DISPATCH, __NAME, __VA_ARGS__)
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_FREE_DISPATCH, __NAME, __VA_ARGS__)
 
-#define ___PRO4_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME)         \
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME)           \
   struct __NAME {                                                              \
     template <class __T, class... __Args>                                      \
-    ___PRO4_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)      \
-    ___PRO4_DIRECT_FUNC_IMPL(__FUNC(::std::forward<__T>(__self),               \
-                                    ::std::forward<__Args>(__args)...))        \
-        ___PRO4_DEF_MEM_ACCESSOR_TEMPLATE(___PRO4_DEF_MEM_ACCESSOR, __FNAME)   \
+    PRO4D_STATIC_CALL(decltype(auto), __T&& __self, __Args&&... __args)        \
+    PRO4D_DIRECT_FUNC_IMPL(__FUNC(::std::forward<__T>(__self),                 \
+                                  ::std::forward<__Args>(__args)...))          \
+        PRO4D_DEF_MEM_ACCESSOR_TEMPLATE(PRO4D_DEF_MEM_ACCESSOR, __FNAME)       \
   }
-#define ___PRO4_DEF_FREE_AS_MEM_DISPATCH_2(__NAME, __FUNC)                     \
-  ___PRO4_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FUNC)
-#define ___PRO4_DEF_FREE_AS_MEM_DISPATCH_3(__NAME, __FUNC, __FNAME)            \
-  ___PRO4_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME)
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_2(__NAME, __FUNC)                       \
+  PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FUNC)
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_3(__NAME, __FUNC, __FNAME)              \
+  PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(__NAME, __FUNC, __FNAME)
 #define PRO4_DEF_FREE_AS_MEM_DISPATCH(__NAME, ...)                             \
-  ___PRO4_EXPAND_MACRO(___PRO4_DEF_FREE_AS_MEM_DISPATCH, __NAME, __VA_ARGS__)
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_FREE_AS_MEM_DISPATCH, __NAME, __VA_ARGS__)
 
 // Version-less macro aliases
 
-#define ___PRO4_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(__NAME,                      \
-                                                  __VERSION_QUALIFIED_NAME)    \
+#define PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(__NAME,                        \
+                                                __VERSION_QUALIFIED_NAME)      \
   static_assert(false, "The use of macro `" #__NAME "` is ambiguous. \
 Are multiple different versions of Proxy library included at the same time?\n\
 Note: To resolve this error: \n\
@@ -207,8 +207,8 @@ stick to a specific major version of the Proxy library.")
 #undef __msft_lib_proxy
 #define __msft_lib_proxy                                                       \
   [] {                                                                         \
-    ___PRO4_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(__msft_lib_proxy,                \
-                                              __msft_lib_proxy4);              \
+    PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(__msft_lib_proxy,                  \
+                                            __msft_lib_proxy4);                \
     return 0L;                                                                 \
   }()
 #else
@@ -218,8 +218,8 @@ stick to a specific major version of the Proxy library.")
 #ifdef PRO_DEF_MEM_DISPATCH
 #undef PRO_DEF_MEM_DISPATCH
 #define PRO_DEF_MEM_DISPATCH(...)                                              \
-  ___PRO4_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_MEM_DISPATCH,              \
-                                            PRO4_DEF_MEM_DISPATCH)
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_MEM_DISPATCH,                \
+                                          PRO4_DEF_MEM_DISPATCH)
 #else
 #define PRO_DEF_MEM_DISPATCH(name, ...) PRO4_DEF_MEM_DISPATCH(name, __VA_ARGS__)
 #endif // PRO_DEF_MEM_DISPATCH
@@ -227,8 +227,8 @@ stick to a specific major version of the Proxy library.")
 #ifdef PRO_DEF_FREE_DISPATCH
 #undef PRO_DEF_FREE_DISPATCH
 #define PRO_DEF_FREE_DISPATCH(...)                                             \
-  ___PRO4_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_DISPATCH,             \
-                                            PRO4_DEF_FREE_DISPATCH)
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_DISPATCH,               \
+                                          PRO4_DEF_FREE_DISPATCH)
 #else
 #define PRO_DEF_FREE_DISPATCH(name, ...)                                       \
   PRO4_DEF_FREE_DISPATCH(name, __VA_ARGS__)
@@ -237,11 +237,11 @@ stick to a specific major version of the Proxy library.")
 #ifdef PRO_DEF_FREE_AS_MEM_DISPATCH
 #undef PRO_DEF_FREE_AS_MEM_DISPATCH
 #define PRO_DEF_FREE_AS_MEM_DISPATCH(...)                                      \
-  ___PRO4_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_AS_MEM_DISPATCH,      \
-                                            PRO4_DEF_FREE_AS_MEM_DISPATCH)
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_AS_MEM_DISPATCH,        \
+                                          PRO4_DEF_FREE_AS_MEM_DISPATCH)
 #else
 #define PRO_DEF_FREE_AS_MEM_DISPATCH(name, ...)                                \
   PRO4_DEF_FREE_AS_MEM_DISPATCH(name, __VA_ARGS__)
 #endif // PRO_DEF_FREE_AS_MEM_DISPATCH
 
-#endif // _MSFT_PROXY4_MACROS_
+#endif // MSFT_PROXY_V4_PROXY_MACROS_H_


### PR DESCRIPTION
As per [[lex.name]](http://www.eel.is/c++draft/lex.name),

> Each identifier that contains a double underscore __ or begins with an underscore followed by an uppercase letter, other than those specified in this document (for example, __cplusplus ([[cpp.predefined]](http://www.eel.is/c++draft/cpp.predefined))), is reserved to the implementation for any use[.](http://www.eel.is/c++draft/lex.name#3.1.sentence-1)
[(3.2)](http://www.eel.is/c++draft/lex.name#3.2)
>
> Each identifier that begins with an underscore is reserved to the implementation for use as a name in the global namespace[.](http://www.eel.is/c++draft/lex.name#3.2.sentence-1)

Macros for internal usage are not supposed to begin with an underscore. Updated the naming of the internal macros to follow the standard naming conventions. No functional changes.