### PR TITLE
Fix MSVC build in debug mode

### DIFF
--- a/tests/proxy_regression_tests.cpp
+++ b/tests/proxy_regression_tests.cpp
@@ -21,6 +21,7 @@ template <class T>
 struct Iterator
     : pro::facade_builder                                                    //
       ::add_skill<pro::skills::direct_rtti>                                  //
+      ::support_relocation<pro::constraint_level::nothrow>                   //
       ::restrict_layout<4 * sizeof(void*)>                                   //
       ::add_direct_convention<pro::operator_dispatch<"++">, void() noexcept> //
       ::add_direct_convention<


### PR DESCRIPTION
This is a regression since #321. For MSVC, `std::vector::iterator` is trivial in release mode, but not trivial in debug mode. No functional changes.

```
proxy_regression_tests.cpp
proxy\include\proxy\v4\proxy.h(652,17): error C2338: static_assert failed: 'not proxiable due to insufficient relocatability'
(compiling source file '../../tests/proxy_regression_tests.cpp')
    proxy\include\proxy\v4\proxy.h(1197,64):
    while evaluating consteval function 'pro::v4::details::facade_traits<F>::diagnose_proxiable'
        with
        [
            F=proxy_regression_tests_details::Iterator<int>
        ]
    proxy\include\proxy\v4\proxy.h(652,17):
    the template instantiation context (the oldest one first) is
        proxy\tests\proxy_regression_tests.cpp(65,37):
        see reference to function template instantiation 'pro::v4::proxy<proxy_regression_tests_details::Range<int>>::proxy<std::vector<int,std::allocator<int>>*>(P &&) noexcept' being compiled
        with
        [
            P=std::vector<int,std::allocator<int>> *
        ]
            proxy\tests\proxy_regression_tests.cpp(65,37):
            see the first reference to 'pro::v4::proxy<proxy_regression_tests_details::Range<int>>::proxy' in 'ProxyRegressionTests_TestProxiableSelfDependency_Test::TestBody'
        proxy\include\proxy\v4\proxy.h(995,5):
        see reference to function template instantiation 'P &pro::v4::proxy<proxy_regression_tests_details::Range<int>>::initialize<std::vector<int,std::allocator<int>>*,_Ty>(_Ty &&)' being compiled
        with
        [
            P=std::vector<int,std::allocator<int>> *,
            _Ty=std::vector<int,std::allocator<int>> *
        ]
        proxy\include\proxy\v4\proxy.h(1194,74):
        see reference to function template instantiation 'pro::v4::details::meta_ptr_indirect_impl<M>::meta_ptr_indirect_impl<std::vector<int,std::allocator<int>>*>(std::in_place_type_t<std::vector<int,std::allocator<int>> *>) noexcept' being compiled
        with
        [
            M=pro::v4::details::composite_meta_impl<pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,true,pro::v4::details::destroy_dispatch,void (void) noexcept>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,false,proxy_regression_tests_details::MemBegin,pro::v4::proxy<proxy_regression_tests_details::Iterator<int>> (void)>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,false,proxy_regression_tests_details::MemEnd,pro::v4::proxy<proxy_regression_tests_details::Iterator<int>> (void)>>
        ]
        proxy\include\proxy\v4\proxy.h(809,15):
        see reference to variable template 'const M pro::v4::details::meta_ptr_indirect_impl<pro::v4::details::composite_meta_impl<pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,1,pro::v4::details::destroy_dispatch,void __cdecl(void) noexcept>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,0,proxy_regression_tests_details::MemBegin,pro::v4::proxy<proxy_regression_tests_details::Iterator<int> > __cdecl(void)>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,0,proxy_regression_tests_details::MemEnd,pro::v4::proxy<proxy_regression_tests_details::Iterator<int> > __cdecl(void)> > >::storage<std::vector<int,std::allocator<int> > *>' being compiled
        with
        [
            M=pro::v4::details::composite_meta_impl<pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,true,pro::v4::details::destroy_dispatch,void (void) noexcept>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,false,proxy_regression_tests_details::MemBegin,pro::v4::proxy<proxy_regression_tests_details::Iterator<int>> (void)>,pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,false,proxy_regression_tests_details::MemEnd,pro::v4::proxy<proxy_regression_tests_details::Iterator<int>> (void)>>
        ]
        proxy\include\proxy\v4\proxy.h(817,29):
        see reference to function template instantiation 'pro::v4::details::composite_meta_impl<I,pro::v4::details::invocation_meta<F,false,proxy_regression_tests_details::MemBegin,pro::v4::proxy<proxy_regression_tests_details::Iterator<T>> (void)>,pro::v4::details::invocation_meta<F,false,proxy_regression_tests_details::MemEnd,pro::v4::proxy<proxy_regression_tests_details::Iterator<T>> (void)>>::composite_meta_impl<std::vector<int,std::allocator<int>>*>(std::in_place_type_t<std::vector<int,std::allocator<int>> *>) noexcept' being compiled
        with
        [
            I=pro::v4::details::invocation_meta<proxy_regression_tests_details::Range<int>,true,pro::v4::details::destroy_dispatch,void (void) noexcept>,
            F=proxy_regression_tests_details::Range<int>,
            T=int
        ]
        proxy\include\proxy\v4\proxy.h(399,11):
        see reference to function template instantiation 'pro::v4::details::invocation_meta<F,false,proxy_regression_tests_details::MemBegin,pro::v4::proxy<proxy_regression_tests_details::Iterator<T>> (void)>::invocation_meta<std::vector<int,std::allocator<int>>*>(std::in_place_type_t<std::vector<int,std::allocator<int>> *>) noexcept' being compiled
        with
        [
            F=proxy_regression_tests_details::Range<int>,
            T=int
        ]
        proxy\include\proxy\v4\proxy.h(388,49):
        see reference to variable template 'R (__cdecl *const __cdecl pro::v4::details::overload_traits_impl<0,0,pro::v4::proxy<proxy_regression_tests_details::Iterator<int> > >::dispatcher<proxy_regression_tests_details::Range<int>,0,proxy_regression_tests_details::MemBegin,std::vector<int,std::allocator<int> > *>)(T &) noexcept(false)' being compiled
        with
        [
            R=pro::v4::proxy<proxy_regression_tests_details::Iterator<int>>,
            T=pro::v4::proxy<proxy_regression_tests_details::Range<int>>
        ]
        proxy\include\proxy\v4\proxy.h(315,8):
        see reference to function template instantiation 'R pro::v4::details::invoke_dispatch<F,false,D,P,pro::v4::details::qualifier_type::lv,false,R,>(T &) noexcept(false)' being compiled
        with
        [
            R=pro::v4::proxy<proxy_regression_tests_details::Iterator<int>>,
            F=proxy_regression_tests_details::Range<int>,
            D=proxy_regression_tests_details::MemBegin,
            P=std::vector<int,std::allocator<int>> *,
            T=pro::v4::proxy<proxy_regression_tests_details::Range<int>>
        ]
        proxy\include\proxy\v4\proxy.h(294,12):
        see reference to function template instantiation 'R pro::v4::details::invoke_dispatch_impl<D,R,std::vector<int,std::allocator<int>>&>(std::vector<int,std::allocator<int>> &)' being compiled
        with
        [
            R=pro::v4::proxy<proxy_regression_tests_details::Iterator<int>>,
            D=proxy_regression_tests_details::MemBegin
        ]
        proxy\include\proxy\v4\proxy.h(269,5):
        see reference to function template instantiation 'pro::v4::proxy<proxy_regression_tests_details::Iterator<T>>::proxy<_Ty>(P &&) noexcept' being compiled
        with
        [
            T=int,
            _Ty=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<int>>>,
            P=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<int>>>
        ]
        proxy\include\proxy\v4\proxy.h(995,5):
        see reference to function template instantiation 'P &pro::v4::proxy<proxy_regression_tests_details::Iterator<T>>::initialize<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>(std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>> &&)' being compiled
        with
        [
            P=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<int>>>,
            T=int,
            _Ty=int
        ]
        proxy\include\proxy\v4\proxy.h(1197,43):
        see reference to function template instantiation 'void pro::v4::details::facade_traits<F>::diagnose_proxiable<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>(void)' being compiled
        with
        [
            F=proxy_regression_tests_details::Iterator<int>,
            _Ty=int
        ]
        proxy\include\proxy\v4\proxy.h(780,9):
        see reference to function template instantiation 'bool pro::v4::details::diagnose_proxiable_insufficient_relocatability<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,F,pro::v4::constraint_level::trivial>(void)' being compiled
        with
        [
            _Ty=int,
            F=proxy_regression_tests_details::Iterator<int>
        ]
proxy\include\proxy\v4\proxy.h(1197,64): error C7595: 'pro::v4::details::facade_traits<F>::diagnose_proxiable': call to immediate function is not a constant expression
proxy\include\proxy\v4\proxy.h(1197,64): error C7595:         with
proxy\include\proxy\v4\proxy.h(1197,64): error C7595:         [
proxy\include\proxy\v4\proxy.h(1197,64): error C7595:             F=proxy_regression_tests_details::Iterator<int>
proxy\include\proxy\v4\proxy.h(1197,64): error C7595:         ]
(compiling source file '../../tests/proxy_regression_tests.cpp')
    proxy\include\proxy\v4\proxy.h(788,17):
    failure was caused by call of undefined function or one not declared 'constexpr'
    proxy\include\proxy\v4\proxy.h(788,17):
    see usage of 'abort'
    proxy\include\proxy\v4\proxy.h(1197,64):
    the call stack of the evaluation (the oldest call first) is
        proxy\include\proxy\v4\proxy.h(1197,64):
        while evaluating function 'void pro::v4::details::facade_traits<F>::diagnose_proxiable<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>(void)'
        with
        [
            F=proxy_regression_tests_details::Iterator<int>,
            _Ty=int
        ]
        proxy\include\proxy\v4\proxy.h(788,17):
        while evaluating function 'void abort(void)'
```