### PR TITLE
Fix return type for prefix operator++ and operator--

### DIFF
--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -2415,7 +2415,23 @@ struct operator_dispatch;
       return proxy_invoke<D, R() oq ne>(static_cast<P pq>(*this));             \
     }                                                                          \
   }
-#define PROD_DEF_LHS_UNARY_OP_ACCESSOR PRO4D_DEF_MEM_ACCESSOR
+#define PROD_DEF_LHS_UNARY_OP_ACCESSOR(oq, pq, ne, ...)                        \
+  template <class P, class D, class R>                                         \
+  struct accessor<P, D, R() oq ne> {                                           \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    decltype(auto) __VA_ARGS__() oq ne {                                       \
+      proxy_invoke<D, R() oq ne>(static_cast<P pq>(*this));                    \
+      return static_cast<P pq>(*this);                                         \
+    }                                                                          \
+  };                                                                           \
+  template <class P, class D, class R>                                         \
+  struct accessor<P, D, R(int) oq ne> {                                        \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    R __VA_ARGS__(int) oq ne {                                                 \
+      return proxy_invoke<D, R(int) oq ne>(static_cast<P pq>(*this), 0);       \
+    }                                                                          \
+  }
+
 #define PROD_DEF_LHS_BINARY_OP_ACCESSOR PRO4D_DEF_MEM_ACCESSOR
 #define PROD_DEF_LHS_ALL_OP_ACCESSOR PRO4D_DEF_MEM_ACCESSOR
 #define PROD_LHS_LEFT_OP_DISPATCH_BODY_IMPL(...)                               \

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -100,22 +100,24 @@ TEST(ProxyDispatchTests, TestOpModulo) {
 
 TEST(ProxyDispatchTests, TestOpIncrement) {
   struct TestFacade
-      : pro::facade_builder::add_convention<pro::operator_dispatch<"++">, int(),
-                                            int(int)>::build {};
+      : pro::facade_builder                                              //
+        ::add_convention<pro::operator_dispatch<"++">, void(), int(int)> //
+        ::add_skill<pro::skills::rtti>::build {};
   int v = 12;
   pro::proxy<TestFacade> p = &v;
-  ASSERT_EQ(++(*p), 13);
+  ASSERT_EQ(proxy_cast<int>(++(*p)), 13);
   ASSERT_EQ((*p)++, 13);
   ASSERT_EQ(v, 14);
 }
 
 TEST(ProxyDispatchTests, TestOpDecrement) {
   struct TestFacade
-      : pro::facade_builder::add_convention<pro::operator_dispatch<"--">, int(),
-                                            int(int)>::build {};
+      : pro::facade_builder                                              //
+        ::add_convention<pro::operator_dispatch<"--">, void(), int(int)> //
+        ::add_skill<pro::skills::rtti>::build {};
   int v = 12;
   pro::proxy<TestFacade> p = &v;
-  ASSERT_EQ(--(*p), 11);
+  ASSERT_EQ(proxy_cast<int>(--(*p)), 11);
   ASSERT_EQ((*p)--, 11);
   ASSERT_EQ(v, 10);
 }


### PR DESCRIPTION
Like assignment operators, accessors for operator `++` and `--` should return a reference to the current `proxy` object when they are used in the prefix form.