### PR TITLE
Improve toolchain coverage

### DIFF
--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -7,16 +7,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: install NVHPC 24.9
+    - name: install NVHPC 25.7
       run: |
         curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
         echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
         sudo apt-get update -y
-        sudo apt-get install -y nvhpc-24-9
+        sudo apt-get install -y nvhpc-25-7
 
-    - name: build and run test with NVHPC 24.9
+    - name: build and run test with NVHPC 25.7
       run: |
-        PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.9/compilers/bin:$PATH; export PATH
+        PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/compilers/bin:$PATH; export PATH
         cmake -B build -GNinja -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++ -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=FALSE
         cmake --build build -j
         ctest --test-dir build -j

--- a/.github/workflows/bvt-oneapi.yml
+++ b/.github/workflows/bvt-oneapi.yml
@@ -1,0 +1,45 @@
+on:
+  workflow_call:
+
+jobs:
+  bvt-oneapi:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install libc++
+      run: |
+        sudo apt-get install -y libc++-19-dev libc++abi-19-dev
+
+    - name: install intel oneAPI
+      run: |
+        sudo wget -qO /etc/apt/trusted.gpg.d/intel-oneapi.asc https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/intel-oneapi.list
+        sudo apt update
+        sudo apt install -y intel-oneapi-compiler-dpcpp-cpp
+        source /opt/intel/oneapi/setvars.sh
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    - name: check compiler version
+      run: |
+        icpx --version
+
+    - name: build and run test with oneapi
+      run: |
+        cmake -B build -GNinja -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-stdlib=libc++"
+        cmake --build build -j
+        ctest --test-dir build -j
+        mkdir build/drop
+        chmod +x tools/dump_build_env.sh
+        ./tools/dump_build_env.sh icpx build/drop/env-info.json
+
+    - name: run benchmarks
+      run: |
+        build/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/drop/benchmarking-results.json
+
+    - name: archive benchmarking results
+      uses: actions/upload-artifact@v4
+      with:
+        name: drop-oneapi
+        path: build/drop/

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -28,6 +28,10 @@ jobs:
     uses: ./.github/workflows/bvt-nvhpc.yml
     name: Run BVT with NVHPC
 
+  run-bvt-icx:
+    uses: ./.github/workflows/bvt-oneapi.yml
+    name: Run BVT with Intel oneAPI
+
   run-bvt-compatibility:
     uses: ./.github/workflows/bvt-compatibility.yml
     name: Run BVT for compatibility
@@ -35,7 +39,7 @@ jobs:
   report:
     uses: ./.github/workflows/bvt-report.yml
     name: Generate report
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc]
+    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc, run-bvt-icx]
 
   mkdocs:
     uses: ./.github/workflows/mkdocs.yml

--- a/README.md
+++ b/README.md
@@ -234,12 +234,13 @@ The "Proxy" library is a self-contained solution for runtime polymorphism in C++
 
 ## <a name="compiler-req">Minimum Requirements for Compilers</a>
 
-| Family     | Minimum version | Required flags |
-| ---------- | --------------- | -------------- |
-| GCC        | 13.1            | -std=c++20     |
-| Clang      | 16.0.0          | -std=c++20     |
-| MSVC       | 19.31           | /std:c++20     |
-| NVIDIA HPC | 24.1            | -std=c++20     |
+| Family       | Minimum version | Required flags |
+| ------------ | --------------- | -------------- |
+| GCC          | 13.1            | -std=c++20     |
+| Clang        | 16.0.0          | -std=c++20     |
+| MSVC         | 19.31           | /std:c++20     |
+| NVIDIA HPC   | 24.1            | -std=c++20     |
+| Intel oneAPI | 2024.0          | -std=c++20     |
 
 ## Build and Run Tests with CMake
 

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -644,6 +644,8 @@ template <class P>
 struct ptr_traits<P> : applicable_traits {};
 template <class F>
 struct ptr_traits<proxy<F>> : inapplicable_traits {};
+template <>
+struct ptr_traits<std::nullptr_t> : inapplicable_traits {};
 
 template <class P, class F, std::size_t ActualSize, std::size_t MaxSize>
 consteval bool diagnose_proxiable_size_too_large() {
@@ -1118,7 +1120,10 @@ public:
     if constexpr (F::relocatability == constraint_level::trivial ||
                   F::copyability == constraint_level::trivial) {
       std::swap(meta_, rhs.meta_);
-      std::swap(ptr_, rhs.ptr_);
+      std::byte temp[F::max_size];
+      std::ranges::uninitialized_copy(ptr_, temp);
+      std::ranges::uninitialized_copy(rhs.ptr_, ptr_);
+      std::ranges::uninitialized_copy(temp, rhs.ptr_);
     } else {
       if (meta_.has_value()) {
         if (rhs.meta_.has_value()) {

--- a/tools/report_generator/report-config.json
+++ b/tools/report_generator/report-config.json
@@ -27,6 +27,11 @@
       "Description": "NVIDIA HPC on Ubuntu",
       "InfoPath": "artifacts/drop-nvhpc/env-info.json",
       "BenchmarkingResultsPath": "artifacts/drop-nvhpc/benchmarking-results.json"
+    },
+    {
+      "Description": "Intel oneAPI on Ubuntu",
+      "InfoPath": "artifacts/drop-oneapi/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-oneapi/benchmarking-results.json"
     }
   ],
   "Metrics": [


### PR DESCRIPTION
**Changes**
 
- Added pipeline for Intel oneAPI C++ compiler and updated README accordingly.
- Updated NVHPC to the latest version.
- Refactored `proxy::swap()` to make it build with Intel oneAPI.
- Added a specialization `details::ptr_traits<std::nullptr_t>` to support libc++ 17.x (builds with Intel oneAPI 2024.x).