### PR TITLE
Forbid conversion from rvalue of `proxy` to `proxy_view`

### DIFF
--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -2135,7 +2135,7 @@ struct view_conversion_dispatch : cast_dispatch_base<false, true> {
   }
 };
 template <class F>
-using view_conversion_overload = proxy_view<F>() noexcept;
+using view_conversion_overload = proxy_view<F>() & noexcept;
 
 struct weak_conversion_dispatch : cast_dispatch_base<false, true> {
   template <class P>

--- a/tests/proxy_view_tests.cpp
+++ b/tests/proxy_view_tests.cpp
@@ -38,6 +38,11 @@ static_assert(
     SupportsToString<decltype(*std::declval<pro::proxy_view<TestFacade>>())>);
 static_assert(sizeof(pro::proxy_view<TestFacade>) == 3 * sizeof(void*));
 
+static_assert(std::is_nothrow_convertible_v<pro::proxy<TestFacade>&,
+                                            pro::proxy_view<TestFacade>>);
+static_assert(!std::is_convertible_v<pro::proxy<TestFacade>,
+                                     pro::proxy_view<TestFacade>>);
+
 template <class F>
 using AreEqualOverload = bool(const pro::proxy_indirect_accessor<F>& rhs,
                               double eps) const;


### PR DESCRIPTION
Conversion from rvalue of `proxy` to `proxy_view` is an anti-pattern. It should be banned. Added unit tests to cover this change.

Resolves #351 