### PR TITLE
Introduce new API: substitution_dispatch

### DIFF
--- a/include/proxy/v4/proxy_macros.h
+++ b/include/proxy/v4/proxy_macros.h
@@ -37,6 +37,20 @@
     return __VA_ARGS__;                                                        \
   }
 
+#define PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(macro, ...)                         \
+  macro(, &, , __VA_ARGS__);                                                   \
+  macro(, &, noexcept, __VA_ARGS__);                                           \
+  macro(&, &, , __VA_ARGS__);                                                  \
+  macro(&, &, noexcept, __VA_ARGS__);                                          \
+  macro(&&, &&, , __VA_ARGS__);                                                \
+  macro(&&, &&, noexcept, __VA_ARGS__);                                        \
+  macro(const, const&, , __VA_ARGS__);                                         \
+  macro(const, const&, noexcept, __VA_ARGS__);                                 \
+  macro(const&, const&, , __VA_ARGS__);                                        \
+  macro(const&, const&, noexcept, __VA_ARGS__);                                \
+  macro(const&&, const&&, , __VA_ARGS__);                                      \
+  macro(const&&, const&&, noexcept, __VA_ARGS__);
+
 #define PRO4D_DEF_AGGREGATE_MEM_ACCESSOR_BODY(...)                             \
   using accessor<ProP, ProD, ProOs>::__VA_ARGS__...;
 #define PRO4D_DEF_AGGREGATE_FREE_ACCESSOR_BODY(...)
@@ -51,18 +65,7 @@
   struct accessor<ProP, ProD, ProOs...> : accessor<ProP, ProD, ProOs>... {     \
     PRO4D_DEF_AGGREGATE_##type##_ACCESSOR_BODY(__VA_ARGS__)                    \
   };                                                                           \
-  macro(, &, , __VA_ARGS__);                                                   \
-  macro(, &, noexcept, __VA_ARGS__);                                           \
-  macro(&, &, , __VA_ARGS__);                                                  \
-  macro(&, &, noexcept, __VA_ARGS__);                                          \
-  macro(&&, &&, , __VA_ARGS__);                                                \
-  macro(&&, &&, noexcept, __VA_ARGS__);                                        \
-  macro(const, const&, , __VA_ARGS__);                                         \
-  macro(const, const&, noexcept, __VA_ARGS__);                                 \
-  macro(const&, const&, , __VA_ARGS__);                                        \
-  macro(const&, const&, noexcept, __VA_ARGS__);                                \
-  macro(const&&, const&&, , __VA_ARGS__);                                      \
-  macro(const&&, const&&, noexcept, __VA_ARGS__);
+  PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(macro, __VA_ARGS__)
 
 #define PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(...)                           \
   PRO4D_DEBUG(accessor() noexcept { ::std::ignore = &accessor::__VA_ARGS__; })

--- a/tests/proxy_dispatch_tests.cpp
+++ b/tests/proxy_dispatch_tests.cpp
@@ -827,3 +827,21 @@ TEST(ProxyDispatchTests, TestFreeAsMemDispatch) {
   pro::proxy<TestFacade> p = &v;
   ASSERT_EQ(p->ToString(), "123");
 }
+
+TEST(ProxyDispatchTests, TestSubstitutionDispatch) {
+  struct Base : pro::facade_builder              //
+                ::add_skill<pro::skills::format> //
+                ::build {};
+  struct TestFacade : pro::facade_builder //
+                      ::add_direct_convention<pro::substitution_dispatch,
+                                              pro::proxy<Base>() const&,
+                                              pro::proxy<Base>() &&> //
+                      ::build {};
+  pro::proxy<TestFacade> p1 = pro::make_proxy<TestFacade>(123);
+  pro::proxy<Base> p2 = p1;
+  ASSERT_TRUE(p1.has_value());
+  ASSERT_EQ(std::format("{}", *p2), "123");
+  pro::proxy<Base> p3 = std::move(p1);
+  ASSERT_FALSE(p1.has_value());
+  ASSERT_EQ(std::format("{}", *p3), "123");
+}


### PR DESCRIPTION
**Changes**

- Renamed `details::upward_conversion_dispatch` into `substitution_dispatch` as a public API, and added support for all 12 overload variants.
- Split `proxy.h` into 7 sections: Core Components, Core Extensions, Proxy Creation, Facade Creation, Skill Extensions, Dispatch Extensions and Adapters.
- Refactored `weak_facade` to decouple from `details::weak_compact_ptr` implementation, and added support for all 12 overload variants.
- Added unit tests accordingly.

Documentation will be updated separately.