### PR TITLE
Fix NVHPC pipeline

### DIFF
--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+
     - name: install NVHPC 25.7
       run: |
         curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg


### PR DESCRIPTION
It seems there were some updates to the preinstalled software, and the remaining disk size become insufficient to install NVHPC. Added a step to free up ~30 GB space.