### PR TITLE
Improve constraints for facade

### DIFF
--- a/docs/spec/ProBasicConvention.md
+++ b/docs/spec/ProBasicConvention.md
@@ -5,7 +5,7 @@ A type `C` meets the *ProBasicConvention* requirements if the following expressi
 | Expressions                  | Semantics                                                    |
 | ---------------------------- | ------------------------------------------------------------ |
 | `C::is_direct`               | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `bool`, specifying whether the convention applies to a pointer type itself (`true`), or the element type of a pointer type (`false`). |
-| `typename C::dispatch_type`  | A [trivial type](https://en.cppreference.com/w/cpp/named_req/TrivialType) that defines how the calls are forwarded to the concrete types. |
+| `typename C::dispatch_type`  | A type that defines how the calls are forwarded to the concrete types. Shall be *nothrow-default-constructible* and *nothrow-destructible*. |
 | `typename C::overload_types` | A [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like) type of one or more distinct types `Os`. Each type `O` in `Os` shall meet the [*ProOverload* requirements](ProOverload.md). |
 
 ## See Also

--- a/docs/spec/ProBasicFacade.md
+++ b/docs/spec/ProBasicFacade.md
@@ -6,11 +6,13 @@ A type `F` meets the *ProBasicFacade* requirements if the following expressions 
 | ------------------------------ | ------------------------------------------------------------ |
 | `typename F::convention_types` | A [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like) type that contains any number of distinct types `Cs`. Each type `C` in `Cs` shall meet the [*ProBasicConvention* requirements](ProBasicConvention.md). |
 | `typename F::reflection_types` | A [tuple-like](https://en.cppreference.com/w/cpp/utility/tuple/tuple-like) type that contains any number of distinct types `Rs`. Each type `R` in `Rs` shall define reflection data structure. |
-| `F::max_size`                  | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `std::size_t` that defines the maximum size of a pointer type. |
-| `F::max_align`                 | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `std::size_t` that defines the maximum alignment of a pointer type. |
+| `F::max_size`                  | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `std::size_t` that defines the maximum size of a pointer type. Shall be greater than `0` and a multiple of `F::max_align`. |
+| `F::max_align`                 | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `std::size_t` that defines the maximum alignment of a pointer type. Shall be a power of `2`. |
 | `F::copyability`               | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type [`constraint_level`](constraint_level.md) that defines the required copyability of a pointer type. |
 | `F::relocatability`            | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type [`constraint_level`](constraint_level.md) that defines the required relocatability of a pointer type. |
 | `F::destructibility`           | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type [`constraint_level`](constraint_level.md) that defines the required destructibility of a pointer type. |
+
+Each of `F::copyability`, `F::relocatability`, and `F::destructibility` shall be exactly one of the four enumerators of `constraint_level` (`none`, `nontrivial`, `nothrow`, `trivial`).
 
 ## See Also
 

--- a/docs/spec/ProBasicReflection.md
+++ b/docs/spec/ProBasicReflection.md
@@ -7,7 +7,7 @@ A type `R` meets the *ProBasicReflection* requirements if the following expressi
 | Expressions                  | Semantics                                                    |
 | ---------------------------- | ------------------------------------------------------------ |
 | `R::is_direct`               | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `bool`, specifying whether the reflection applies to a pointer type itself (`true`), or the element type of a pointer type (`false`). |
-| `typename R::reflector_type` | A [trivial type](https://en.cppreference.com/w/cpp/named_req/TrivialType) that defines the data structure reflected from the type. |
+| `typename R::reflector_type` | A type that defines the data structure reflected from the type. Shall be *nothrow-default-constructible* and *nothrow-destructible*. |
 
 ## See Also
 

--- a/docs/spec/basic_facade_builder/README.md
+++ b/docs/spec/basic_facade_builder/README.md
@@ -12,7 +12,7 @@ constexpr constraint_level default-cl = static_cast<constraint_level>(
     std::numeric_limits<std::underlying_type_t<constraint_level>>::min()); // exposition only
 ```
 
-Given a [facade](../facade.md ) type `F`, any meaningful value of `F::max_size` and `F::max_align` is less than *default-size*; any meaningful value of `F::copyability`, `F::relocatability`, and `F::destructibility` is greater than *default-cl*.
+Given a [facade](../facade.md) type `F`, any meaningful value of `F::max_size` and `F::max_align` is less than *default-size*; any meaningful value of `F::copyability`, `F::relocatability`, and `F::destructibility` is greater than *default-cl*.
 
 ```cpp
 template <class Cs, class Rs, std::size_t MaxSize, std::size_t MaxAlign,
@@ -54,7 +54,7 @@ using facade_builder =
 
 ## Notes
 
-The design of `basic_facade_builder` utilizes template metaprogramming techniques. We recommend the following 2 guidelines when using `basic_facade_builder` to define a facade type.
+The design of `basic_facade_builder` utilizes template metaprogramming techniques. We recommend the following guidelines when using `basic_facade_builder` to define a facade type.
 
 - **Define a type for each facade.**
 

--- a/docs/spec/basic_facade_builder/restrict_layout.md
+++ b/docs/spec/basic_facade_builder/restrict_layout.md
@@ -2,11 +2,11 @@
 
 ```cpp
 template <std::size_t PtrSize, std::size_t PtrAlign = /* see below */>
-    requires(std::has_single_bit(PtrAlign) && PtrSize % PtrAlign == 0u)
+    requires(PtrSize > 0u && std::has_single_bit(PtrAlign) && PtrSize % PtrAlign == 0u)
 using restrict_layout = basic_facade_builder</* see below */>;
 ```
 
-The alias template `restrict_layout` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds layout restrictions to the template parameters. The default value of `PtrAlign` is the maximum possible alignment of an object of size `PtrSize`, not greater than `alignof(std::max_align_t`). After applying the restriction, `MaxSize` becomes `std::min(MaxSize, PtrSize)`, and `MaxAlign` becomes `std::min(C::max_align, MaxAlign)`.
+The alias template `restrict_layout` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds layout restrictions to the template parameters. The default value of `PtrAlign` is the maximum possible alignment of an object of size `PtrSize`, not greater than `alignof(std::max_align_t)`. After applying the restriction, `MaxSize` becomes `std::min(MaxSize, PtrSize)`, and `MaxAlign` becomes `std::min(C::max_align, MaxAlign)`.
 
 ## Notes
 

--- a/docs/spec/basic_facade_builder/support_copy.md
+++ b/docs/spec/basic_facade_builder/support_copy.md
@@ -2,10 +2,11 @@
 
 ```cpp
 template <constraint_level CL>
+    requires(/* see below */)
 using support_copy = basic_facade_builder</* see below */>;
 ```
 
-The alias template `support_copy` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds copyability support to the template parameters. After the operation, `Copyability` becomes `std::max(Copyability, CL)`.
+The alias template `support_copy` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds copyability support to the template parameters. After the operation, `Copyability` becomes `std::max(Copyability, CL)`. The expression inside `requires` is equivalent to `CL` is a defined enumerator of `constraint_level`.
 
 ## Notes
 

--- a/docs/spec/basic_facade_builder/support_destruction.md
+++ b/docs/spec/basic_facade_builder/support_destruction.md
@@ -2,10 +2,11 @@
 
 ```cpp
 template <constraint_level CL>
+    requires(/* see below */)
 using support_destruction = basic_facade_builder</* see below */>;
 ```
 
-The alias template `support_destruction` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds destruction support to the template parameters. After the operation, `Destructibility` becomes `std::max(Destructibility, CL)`.
+The alias template `support_destruction` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds destruction support to the template parameters. After the operation, `Destructibility` becomes `std::max(Destructibility, CL)`. The expression inside `requires` is equivalent to `CL` is a defined enumerator of `constraint_level`.
 
 ## Notes
 

--- a/docs/spec/basic_facade_builder/support_relocation.md
+++ b/docs/spec/basic_facade_builder/support_relocation.md
@@ -2,10 +2,11 @@
 
 ```cpp
 template <constraint_level CL>
+    requires(/* see below */)
 using support_relocation = basic_facade_builder</* see below */>;
 ```
 
-The alias template `support_relocation` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds relocatability support to the template parameters. After the operation, `Relocatability` becomes `std::max(Relocatability, CL)`.
+The alias template `support_relocation` of `basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability, Relocatability, Destructibility>` adds relocatability support to the template parameters. After the operation, `Relocatability` becomes `std::max(Relocatability, CL)`. The expression inside `requires` is equivalent to `CL` is a defined enumerator of `constraint_level`.
 
 ## Notes
 


### PR DESCRIPTION
**Changes**

This PR aligns with the proposed changes in #358.

- Strengthened the *ProBasicFacade.md* requirements.
  - Added constraints `F::max_size > 0`, `F::max_size` shall be a multiple of `F::max_align` and `F::max_align` shall be a power of `2`.
  - Added constraints `F::copyability/relocatability/destructibility` shall be exactly one of the four enumerators of `constraint_level`.
  - Updated the use of "trivial type" to "*nothrow-default-constructible* and *nothrow-destructible*".
- Added constraints to `basic_facade_builder::support_copy/support_relocation/support_destruction/restrict_layout` accordingly.
- Updated the implementation and unit tests accordingly.