### PR TITLE
Fix overload resolution in `PRO_DEF_FREE_AS_MEM_DISPATCH`

### DIFF
--- a/include/proxy/v4/proxy_macros.h
+++ b/include/proxy/v4/proxy_macros.h
@@ -141,7 +141,7 @@
     PRO4D_STATIC_CALL(decltype(auto), ProT&& pro_self, ProArgs&&... pro_args)  \
     PRO4D_DIRECT_FUNC_IMPL(impl(::std::forward<ProT>(pro_self),                \
                                 ::std::forward<ProArgs>(pro_args)...))         \
-        PRO4D_DEF_ACCESSOR_TEMPLATE(FREE, PRO4D_DEF_MEM_ACCESSOR, func)        \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(MEM, PRO4D_DEF_MEM_ACCESSOR, func)         \
   }
 #define PRO4D_DEF_FREE_AS_MEM_DISPATCH_2(name, impl)                           \
   PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(name, impl, impl)


### PR DESCRIPTION
This is a regression caused by #320. Added unit tests to cover overload resolution for all member, free, and free-as-mem dispatch.

Resolves #371 